### PR TITLE
Softmax sparse implementation

### DIFF
--- a/ML/Classify.ecl
+++ b/ML/Classify.ecl
@@ -1025,7 +1025,122 @@ EXPORT Logistic_sparse(REAL8 Ridge=0.00001, REAL8 Epsilon=0.000000001, UNSIGNED2
     END;
     
     END; // Logistic Module 
-    
+
+// Implementation of SoftMax classifier
+//SoftMax classifier generalizes logistic regression classifier for cases when we have more than two target classes
+//The implemenataion is based on Stanford Deep Learning tutorial availabe at http://ufldl.stanford.edu/wiki/index.php/Softmax_Regression
+//this implementation is based on using ML.Mat library
+
+//parameters:
+//LAMBDA : wight decay parameter in calculating SoftMax costfunction
+//ALPHA : learning rate for updating softmax parameters
+//IntTHETA: Initialized parameters that is a matrix of size (number of classes) * (number of features)
+
+  EXPORT SoftMax_Sparse(DATASET (MAT.Types.Element) IntTHETA, REAL8 LAMBDA=0.001, REAL8 ALPHA=0.1, UNSIGNED2 MaxIter=100) := MODULE(DEFAULT)
+
+  Soft(DATASET(Types.NumericField) X,DATASET(Types.NumericField) Y) := MODULE
+
+    //Convert the input data to matrix
+  //the reason matrix transform is done after ocnverting the input data to the matrix is that
+  //in this implementation it is assumed that the  input matrix shows the samples in column-wise format
+  //in other words each sample is shown in one column. that's why after converting the input to matrix we apply
+  //matrix tranform to refletc samples in column-wise format
+  dt := Types.ToMatrix (X);
+  SHARED dTmp := Mat.InsertColumn(dt,1,1.0);
+  SHARED d := Mat.Trans(dTmp);
+  SHARED groundTruth:= Utils.ToGroundTruth (Y);
+
+  Step(DATASET(Mat.Types.Element) THETA) := FUNCTION
+    m := MAX (d, d.y); //number of samples
+    // tx=(theta*d);
+    tx := Mat.Mul (THETA, d);
+    // tx_M = bsxfun(@minus, tx, max(tx, [], 1));
+    MaxCol_tx := Mat.Has(tx).MaxCol;
+    Mat.Types.Element DoMinus(tx le,MaxCol_tx ri) := TRANSFORM
+      SELF.x := le.x;
+      SELF.y := le.y;
+      SELF.value := le.value - ri.value;
+    END;
+    tx_M :=  JOIN(tx, MaxCol_tx, LEFT.y=RIGHT.y, DoMinus(LEFT,RIGHT));
+    //exp_tx_M=exp(tx_M);
+    exp_tx_M := Mat.Each.Exp(tx_M);
+    //Prob = bsxfun(@rdivide, exp_tx_M, sum(exp_tx_M));
+    SumCol_exp_tx_M := Mat.Has(exp_tx_M).SumCol;
+    Mat.Types.Element DoDiv(exp_tx_M le,SumCol_exp_tx_M ri) := TRANSFORM
+      SELF.x := le.x;
+      SELF.y := le.y;
+      SELF.value := le.value / ri.value;
+    END;
+    Prob :=  JOIN(exp_tx_M, SumCol_exp_tx_M, LEFT.y=RIGHT.y, DoDiv(LEFT,RIGHT));
+    //thetagrad=((-1/m)*(groundTruth-M)*x')+lambda*theta;
+    second_term := Mat.Scale (THETA, LAMBDA);
+    groundTruth_Prob := Mat.Sub (groundTruth, Prob);
+    groundTruth_Prob_x := Mat.Mul (groundTruth_Prob, dTmp);
+    m_1 := -1 * (1/m);
+    first_term := Mat.Scale(groundTruth_Prob_x, m_1);
+    THETAGrad := Mat.Add (first_term, second_term);
+    //now that the gradient is calculated update the parameters based on the update rule below:
+    //new_param = old_param - ALPHA*param_grad
+    AlphaGrad := Mat.Scale (THETAGrad, ALPHA);
+    UpdatedTHETA := Mat.Sub (THETA,AlphaGrad);
+    RETURN UpdatedTHETA;
+  END; // END Step
+  Param := LOOP(IntTHETA, MaxIter, Step(ROWS(LEFT)));
+  EXPORT Mod := Types.FromMatrix (Param);
+  END; //END Soft
+  EXPORT LearnC(DATASET(Types.NumericField) Indep, DATASET(Types.DiscreteField) Dep) := Soft(Indep,PROJECT(Dep,Types.NumericField)).mod;
+  EXPORT Model(DATASET(Types.NumericField) mod) := FUNCTION
+  o:= Types.ToMatrix (Mod);
+  RETURN o;
+  END;
+  EXPORT ClassProbDistribC(DATASET(Types.NumericField) Indep,DATASET(Types.NumericField) mod) :=FUNCTION
+   // the steps taken here are the same steps taken above in step fucntion to calculate Prob
+   param := Model (mod);
+   dTmp := Types.ToMatrix (Indep);
+   x := Mat.Trans(dTmp);
+   tx := Mat.Mul (param, x);
+   MaxCol_tx := Mat.Has(tx).MaxCol;
+  Mat.Types.Element DoMinus(tx le,MaxCol_tx ri) := TRANSFORM
+    SELF.x := le.x;
+    SELF.y := le.y;
+    SELF.value := le.value - ri.value;
+    END;
+  tx_M :=  JOIN(tx, MaxCol_tx, LEFT.y=RIGHT.y, DoMinus(LEFT,RIGHT));
+  exp_tx_M := Mat.Each.Exp(tx_M);
+  SumCol_exp_tx_M := Mat.Has(exp_tx_M).SumCol;
+  Mat.Types.Element DoDiv(exp_tx_M le,SumCol_exp_tx_M ri) := TRANSFORM
+    SELF.x := le.x;
+    SELF.y := le.y;
+    SELF.value := le.value / ri.value;
+    END;
+  Prob :=  JOIN(exp_tx_M, SumCol_exp_tx_M, LEFT.y=RIGHT.y, DoDiv(LEFT,RIGHT)); // each column of the Prob matrix includes the probabilities of the corresponding sampel for each of calsses
+  Types.l_result tr(Mat.Types.Element le) := TRANSFORM
+    SELF.value := le.x;
+    SELF.id := le.y;
+    SELF.number := 1; //number of class
+    SELF.conf := le.value;
+    SELF.closest_conf := 0;
+  END;
+  RETURN PROJECT (Prob, tr(LEFT));
+  END; // ClassProbDistribC
+  EXPORT ClassifyC(DATASET(Types.NumericField) Indep,DATASET(Types.NumericField) mod) := FUNCTION
+  Dist := ClassProbDistribC(Indep, mod);
+  numrow := MAX (Dist,Dist.value);
+  S:= SORT(Dist,id,conf);
+  SeqRec := RECORD
+  l_result;
+  INTEGER8 Sequence := 0;
+  END;
+  //add seq field to S
+  SeqRec AddS (S l, INTEGER c) := TRANSFORM
+  SELF.Sequence := c%numrow;
+  SELF := l;
+  END;
+  Sseq := PROJECT(S, AddS(LEFT,COUNTER));
+  classified := Sseq (Sseq.Sequence=0);
+  RETURN PROJECT(classified,l_result);
+END; // END ClassifyC
+END; //END SoftMax_Sparse
 /* From Wikipedia: 
 http://en.wikipedia.org/wiki/Decision_tree_learning#General
 "... Decision tree learning is a method commonly used in data mining.

--- a/ML/Mat/Each.ecl
+++ b/ML/Mat/Each.ecl
@@ -1,4 +1,4 @@
-// Element-wise matrix operations
+﻿// Element-wise matrix operations
 IMPORT ML.Mat.Types;
 EXPORT Each := MODULE
 
@@ -9,7 +9,6 @@ EXPORT Sqrt(DATASET(Types.Element) d) := FUNCTION
 	END;
 	RETURN PROJECT(d,fn(LEFT));
 END;
-	
 EXPORT Exp(DATASET(Types.Element) d) := FUNCTION
   Types.Element fn(d le) := TRANSFORM
 	  SELF.value := exp(le.value);
@@ -36,7 +35,6 @@ Types.Element Multiply(l le,r ri) := TRANSFORM
 	RETURN JOIN(l,r,LEFT.x=RIGHT.x AND LEFT.y=RIGHT.y,Multiply(LEFT,RIGHT));
 END;
 
-
 // matrix .+ scalar
 EXPORT Add(DATASET(Types.Element) d,Types.t_Value scalar) := FUNCTION
   Types.Element add(d le) := TRANSFORM
@@ -56,5 +54,22 @@ EXPORT Reciprocal(DATASET(Types.Element) d, Types.t_Value factor=1) := FUNCTION
 	END;
 	RETURN PROJECT(d,divide(LEFT));
  END;
-
+//sigmoid function
+  EXPORT sigmoid(DATASET(Types.Element) l) := FUNCTION
+    Types.Element sig(l le) := TRANSFORM
+      SELF.value := 1 / (1 + EXP(le.value * -1));
+      SELF := le;
+      END;
+    P := PROJECT(l, sig(LEFT)); //perfomr sigmoid function on each record
+    RETURN P;
+  END;
+//logarithm
+  EXPORT Logarithm(DATASET(Types.Element) l) := FUNCTION //apply Logarithm on each element of matrix
+  Types.Element DoL(l le) := TRANSFORM
+    SELF.value := LOG (le.value);
+    SELF := le;
+  END;
+  R := PROJECT(l, DoL(LEFT));
+  RETURN R;
+  END;
 END;

--- a/ML/Mat/Has.ecl
+++ b/ML/Mat/Has.ecl
@@ -36,4 +36,67 @@ END;
 // MeanCol is a row vector containing the mean value of each column.
 EXPORT MeanCol := TABLE(d,r,d.y);
 
+r := RECORD
+  Types.t_Index x := d.x ;
+  Types.t_Index y := 1;
+  Types.t_Value value := MAX(GROUP,d.value);
+END;
+
+// MaxRow is a column vector containing the max value of each row.
+EXPORT MaxRow := TABLE(d,r,d.x);
+
+r := RECORD
+  Types.t_Index x := 1 ;
+  Types.t_Index y := d.y;
+  Types.t_Value value := MAX(GROUP,d.value);
+END;
+
+// MaxCol is a row vector containing the max value of each column.
+EXPORT MaxCol := TABLE(d,r,d.y);
+
+r := RECORD
+  Types.t_Index x := d.x ;
+  Types.t_Index y := 1;
+  Types.t_Value value := SUM(GROUP,d.value);
+END;
+
+// SumRow is a column vector containing the sum value of each row.
+EXPORT SumRow := TABLE(d,r,d.x);
+
+r := RECORD
+  Types.t_Index x := 1 ;
+  Types.t_Index y := d.y;
+  Types.t_Value value := SUM(GROUP,d.value);
+END;
+
+// SumCol is a row vector containing the sum value of each column.
+EXPORT SumCol := TABLE(d,r,d.y);
+
+//return the index of the maximun value in each colomn
+  EXPORT MaxColIndex := FUNCTION
+  numrow := MAX (d,d.x);
+  S := SORT (d, y,value);
+  SequencedS := RECORD
+    Types.Element;
+    INTEGER8 Sequence := 0;
+  END;
+
+  SequencedS AddSequence(S l, INTEGER c) := TRANSFORM
+    SELF.Sequence := c%numrow;
+    SELF := l;
+  END;
+
+  SequencedSRecs := PROJECT(S,AddSequence(LEFT,COUNTER));
+  out := SequencedSRecs (SequencedSRecs.Sequence=0);
+
+  Types.Element makematrix(SequencedS l) := TRANSFORM
+    SELF.x := 1;
+    SELF.value :=  l.x;
+    SELF.y := l.y;
+  END;
+
+  final_result := PROJECT (out, makematrix(LEFT));
+
+  RETURN final_result;
+  END;
 END;

--- a/ML/Mat/RandMat.ecl
+++ b/ML/Mat/RandMat.ecl
@@ -1,0 +1,36 @@
+﻿IMPORT * FROM ML.Mat;
+
+
+
+Produce_Random () := FUNCTION
+
+G := 1000000;
+
+R := (RANDOM()%G) / (REAL8)G;
+
+RETURN R;
+
+END;
+
+
+
+//return a matrix with "Nrows" number of rows and "NCols" number of cols. The  matrix is initilized with random numbers
+EXPORT RandMat (UNSIGNED Nrows, UNSIGNED NCols) := FUNCTION
+
+
+ONE := DATASET ([{1,1,0}],Types.Element);
+
+MatZero := Mat.Repmat (ONE, Nrows, NCols); // matrix of zeros of the size NRows*NCols
+
+//replce zero values in MatZero with random generated values
+Types.Element RandomizeMat(Types.Element l) := TRANSFORM
+  r1 := Produce_Random();
+  Self.Value := r1;
+  Self := l;
+END;
+
+
+Result := PROJECT (MatZero,RandomizeMat(LEFT) );
+RETURN Result;
+
+END;

--- a/ML/Tests/Explanatory/SoftMax_Sparse.ecl
+++ b/ML/Tests/Explanatory/SoftMax_Sparse.ecl
@@ -1,0 +1,72 @@
+﻿IMPORT * FROM ML;
+IMPORT * FROM $;
+
+//Set Parameters
+LoopNum := 1; // Number of iterations in softmax algortihm
+LAMBDA := 0.0001; // weight decay parameter in  claculation of SoftMax Cost fucntion
+ALPHA := 0.1; // //Learning Rate for updating SoftMax parameters
+
+//input data
+value_record := RECORD
+  unsigned  id;
+  real  f1;
+  real  f2;
+  integer1  label;
+END;
+input_data := DATASET([
+{1, 0.1, 0.2,1},
+{2, 0.8, 0.9,2},
+{3, 0.5, 0.9,3},
+{4, 0.8, 0.7,3},
+{5, 0.9,0.1,2},
+{6, 0.1, 0.3,1}],
+ value_record);
+OUTPUT  (input_data, ALL, NAMED ('input_data'));
+
+//convert input data to two datset: samples dataset and labels dataset
+Sampledata_Format := RECORD
+  input_data.id;
+  input_data.f1;
+  input_data.f2;
+END;
+
+sample_table := TABLE(input_data,Sampledata_Format);
+OUTPUT  (sample_table, ALL, NAMED ('sample_table'));
+
+labeldata_Format := RECORD
+  input_data.id;
+  input_data.label;
+END;
+
+label_table := TABLE(input_data,labeldata_Format);
+OUTPUT  (label_table, ALL, NAMED ('label_table'));
+
+
+ML.ToField(sample_table, indepDataC);
+OUTPUT  (indepDataC, ALL, NAMED ('indepDataC'));
+ML.ToField(label_table, depDataC);
+OUTPUT  (depDataC, ALL, NAMED ('depDataC'));
+label := PROJECT(depDataC,Types.DiscreteField);
+OUTPUT  (label, ALL, NAMED ('label'));
+
+//initialize THETA
+Numclass := MAX (label, label.value);
+OUTPUT  (Numclass, ALL, NAMED ('Numclass'));
+InputSize := MAX (indepDataC,indepDataC.number);
+OUTPUT  (InputSize, ALL, NAMED ('InputSize'));
+T1 := Mat.RandMat (Numclass,InputSize+1);
+OUTPUT  (T1, ALL, NAMED ('T1'));
+IntTHETA := Mat.Scale (T1,0.005);
+OUTPUT  (IntTHETA, ALL, NAMED ('IntTHETA'));
+//SoftMax_Sparse Classfier
+trainer:= ML.Classify.SoftMax_Sparse(IntTHETA, LAMBDA, ALPHA, LoopNum);
+
+//Learning Phase
+Model := trainer.LearnC(indepDataC, label);
+OUTPUT  (Model, ALL, NAMED ('Model'));
+
+//test phase
+dist := trainer.ClassProbDistribC(indepDataC,Model );
+classified := trainer.ClassifyC(indepDataC,Model);
+OUTPUT  (dist, ALL, NAMED ('dist'));
+OUTPUT  (classified, ALL, NAMED ('classified'));

--- a/ML/Utils.ecl
+++ b/ML/Utils.ecl
@@ -434,7 +434,26 @@ RETURN TABLE(LOOP(Init,K,Permutate(ROWS(LEFT))), {Kperm});
 
 END;
 	
+EXPORT ToGroundTruth(DATASET(Types.NumericField) Y ) := FUNCTION
 
-	
+
+zero_mat    := DATASET ([{1,1,0}],Mat.Types.Element);
+sample_num  := MAX (Y,Y.id);
+class_num   := MAX (Y, Y.value);
+scratch_mat := Mat.Repmat (zero_mat, class_num, sample_num);
+
+
+
+Mat.Types.Element ToGT(scratch_mat l, Y r) := TRANSFORM
+  SELF.value := IF(l.x=r.value,1,0);
+  SELF := l;
+END;
+
+
+Result := JOIN (scratch_mat, Y, LEFT.y=RIGHT.id , ToGT(LEFT,RIGHT));
+
+RETURN Result;
+
+END; // END ToGroundTruth
 	
 END;


### PR DESCRIPTION
The implementation is based on the stanfrod's deep learning tutorial
available at http://ufldl.stanford.edu/wiki/index.php/Softmax_Regression
This implementation is based on using ML.Mat library.
Test file is added to ML/Tests/Explanatory
The implementation is tested on this toy dataset to compare the results with
the results I get from my MATLAB implementation
Some functions are added to Mat.Has and Mat.Each
RandMat is added to ML.Mat that initializes a randome matrix
the fucntion ToGroundTruth is added to ML.Utils. This function converts the label
data to a specific matrix format for the label data that is used in the implementations.
The matrix is a "number of classes"*"number of samples" matrix.
each column is corresponded to one sample. All the lements are zero in one column
unless the element that it's row number is the same as the lable of that sample which
takes the value "1". in other word M(r, c) is 1 if y(c) = r and 0 otherwise