### PR TITLE
Naive Bayes CPD + Classify.ecl cleaning …

### DIFF
--- a/ML/Classify.ecl
+++ b/ML/Classify.ecl
@@ -31,20 +31,14 @@ EXPORT Compare(DATASET(Types.DiscreteField) Dep,DATASET(l_result) Computed) := M
 		Types.t_Discrete  c_actual;      // The value of c provided
 		Types.t_Discrete  c_modeled;		 // The value produced by the classifier
 		Types.t_FieldReal score;         // Score allocated by classifier
-		Types.t_FieldReal score_delta;   // Difference to next best
-		BOOLEAN           sole_result;   // Did the classifier only have one option
 	END;
 	DiffRec  notediff(Computed le,Dep ri) := TRANSFORM
 	  SELF.c_actual := ri.value;
 		SELF.c_modeled := le.value;
 		SELF.score := le.conf;
-		SELF.score_delta := IF ( le.closest_conf>0, le.closest_conf-le.conf,0 );
-		SELF.sole_result := le.closest_conf=0;
 		SELF.classifier := ri.number;
 	END;
 	SHARED J := JOIN(Computed,Dep,LEFT.id=RIGHT.id AND LEFT.number=RIGHT.number,notediff(LEFT,RIGHT));
-	// Shows which classes were modeled as which classes
-	EXPORT Raw := TABLE(J,{classifier,c_actual,c_modeled,score,score_delta,sole_result,Cnt := COUNT(GROUP)},classifier,c_actual,c_modeled,score,score_delta,sole_result,MERGE);
 	// Building the Confusion Matrix
 	SHARED ConfMatrix_Rec := RECORD
 		Types.t_FieldNumber classifier;	// The classifier in question (value of 'number' on outcome data)
@@ -87,8 +81,7 @@ EXPORT Compare(DATASET(Types.DiscreteField) Dep,DATASET(l_result) Computed) := M
   EXPORT FP_Rate_ByClass := JOIN(wrong_modeled, allfalse, LEFT.classifier=RIGHT.classifier AND LEFT.c_modeled=RIGHT.c_modeled,
                           TRANSFORM(FalseRate_rec, SELF.fp_rate:= LEFT.wcnt/RIGHT.not_actual, SELF:= LEFT));
 // Accuracy, it returns the proportion of instances correctly classified (total, without class distinction)
-  EXPORT HeadLine := TABLE(CrossAssignments, {classifier, Accuracy:= SUM(GROUP,IF(c_actual=c_modeled,cnt,0))/SUM(GROUP, cnt)}, classifier);
-  EXPORT Accuracy := HeadLine;
+  EXPORT Accuracy := TABLE(CrossAssignments, {classifier, Accuracy:= SUM(GROUP,IF(c_actual=c_modeled,cnt,0))/SUM(GROUP, cnt)}, classifier);
 END;
 /*
 	The purpose of this module is to provide a default interface to provide access to any of the 
@@ -274,9 +267,9 @@ END;
     END;
 		// This function will take a pre-existing NaiveBayes model (mo) and score every row of a discretized dataset
 		// The output will have a row for every row of dd and a column for every class in the original training set
-		EXPORT ClassifyD(DATASET(Types.DiscreteField) Indep,DATASET(Types.NumericField) mod) := FUNCTION
-		   d := Indep;
-			 mo := Model(mod);
+    EXPORT ClassProbDistribD(DATASET(Types.DiscreteField) Indep,DATASET(Types.NumericField) mod) := FUNCTION
+      d := Indep;
+      mo := Model(mod);
       // Firstly we can just compute the support for each class from the bayes result
 			dd := DISTRIBUTE(d,HASH(id)); // One of those rather nice embarassingly parallel activities
 			Inter := RECORD
@@ -317,25 +310,28 @@ END;
 				SELF := le;
 			END;
 			CNoted := JOIN(MissingNoted,mo(number=0),LEFT.c=RIGHT.c,NoteC(LEFT,RIGHT),LOOKUP);
-			S := DEDUP(SORT(CNoted,Id,class_number,P,c,LOCAL),Id,class_number,LOCAL,KEEP(2));
-
-			l_result tr(S le) := TRANSFORM
-			  SELF.value := le.c; // Store the value of the classifier
-				SELF.number := le.class_number; 
-				SELF.Conf := le.p;
-				SELF.closest_conf := 0;
-				SELF.id := le.id;
-			END;
-			
-			ST := PROJECT(S,tr(LEFT));
-			l_result rem(ST le, ST ri) := TRANSFORM
-				SELF.closest_conf := ri.conf;
-				SELF := le;
-			END;
-			Ro := ROLLUP(ST,LEFT.id=RIGHT.id AND LEFT.number=RIGHT.number,rem(LEFT,RIGHT),LOCAL);
-			RETURN Ro;
-		END;
-    /*From Wikipedia    
+      l_result toResult(CNoted le) := TRANSFORM
+        SELF.id := le.id;               // Instance ID
+        SELF.number := le.class_number; // Classifier ID
+        SELF.value := le.c;             // Class value
+        SELF.conf := POWER(2.0, -le.p); // Convert likehood to decimal value
+      END;
+      // Normalizing Likehood to deliver Class Probability per instance
+      InstResults := PROJECT(CNoted, toResult(LEFT), LOCAL);
+      gInst := TABLE(InstResults, {number, id, tot:=SUM(GROUP,conf)}, number, id, LOCAL);
+      clDist:= JOIN(InstResults, gInst,LEFT.number=RIGHT.number AND LEFT.id=RIGHT.id, TRANSFORM(Types.l_result, SELF.conf:=LEFT.conf/RIGHT.tot, SELF:=LEFT), LOCAL);
+      RETURN clDist;
+    END;
+    // Classification function for discrete independent values and model
+    EXPORT ClassifyD(DATASET(Types.DiscreteField) Indep,DATASET(Types.NumericField) mod) := FUNCTION
+      // get class probabilities for each instance
+      dClass:= ClassProbDistribD(Indep, mod);
+      // select the class with greatest probability for each instance
+      sClass := SORT(dClass, id, -conf, LOCAL);
+      finalClass:=DEDUP(sClass, id, LOCAL);
+      RETURN finalClass;
+    END;
+    /*From Wikipedia
     " ...When dealing with continuous data, a typical assumption is that the continuous values associated with each class are distributed according to a Gaussian distribution.
     For example, suppose the training data contain a continuous attribute, x. We first segment the data by the class, and then compute the mean and variance of x in each class.
     Let mu_c be the mean of the values in x associated with class c, and let sigma^2_c be the variance of the values in x associated with class c.
@@ -393,7 +389,7 @@ END;
       ML.FromField(mod,BayesResultC,o);
       RETURN o;
     END;
-    EXPORT ClassifyC(DATASET(Types.NumericField) Indep, DATASET(Types.NumericField) mod) := FUNCTION
+    EXPORT ClassProbDistribC(DATASET(Types.NumericField) Indep, DATASET(Types.NumericField) mod) := FUNCTION
       dd := DISTRIBUTE(Indep, HASH(id));
       mo := ModelC(mod);
       Inter := RECORD
@@ -425,11 +421,33 @@ END;
       // Posterior probability = prior x likehood_product / evidence
       // We use only the numerator of that fraction, because the denominator is effectively constant.
       // See: http://en.wikipedia.org/wiki/Naive_Bayes_classifier#Probabilistic_model
-      AllPosterior:= JOIN(LikehoodProduct, LogPC, LEFT.class_number = RIGHT.class_number AND LEFT.c = RIGHT.c, TRANSFORM(l_result, SELF.conf:= LEFT.prod + RIGHT.mu, SELF.number:=LEFT.class_number, SELF.value:= RIGHT.c, SELF.closest_conf:= 0, SELF:=LEFT), LOOKUP);
-      sortPost:= SORT(AllPosterior, id, number, conf, LOCAL);
-      // The class with greatest posterior probability is selected (smallest prod cause we are using LogScale values)
-      RETURN DEDUP(sortPost, LEFT.id=RIGHT.id AND LEFT.number=RIGHT.number);
+      l_result toResult(LikehoodProduct le, LogPC ri) := TRANSFORM
+        SELF.id := le.id;               // Instance ID
+        SELF.number := le.class_number; // Classifier ID
+        SELF.value := ri.c;             // Class value
+        SELF.conf:= le.prod + ri.mu;    // Adding mu
+      END;
+      AllPosterior:= JOIN(LikehoodProduct, LogPC, LEFT.class_number = RIGHT.class_number AND LEFT.c = RIGHT.c, toResult(LEFT, RIGHT), LOOKUP);
+      // Normalizing Likehood to deliver Class Probability per instance
+      baseExp:= TABLE(AllPosterior, {id, minConf:= MIN(GROUP, conf)},id, LOCAL); // will use this to divide instance's conf by the smallest per id
+      l_result toNorm(AllPosterior le, baseExp ri) := TRANSFORM
+        SELF.conf:= POWER(2.0, -MIN( le.conf - ri.minConf, 2048));  // minimum probability set to 1/2^2048 = 0 at the end
+        SELF:= le;
+      END;
+      AllOffset:= JOIN(AllPosterior, baseExp, LEFT.id = RIGHT.id, toNorm(LEFT, RIGHT), LOOKUP); // at least one record per id with 1.0 probability before normalization
+      gInst := TABLE(AllOffset, {number, id, tot:=SUM(GROUP,conf)}, number, id, LOCAL);
+      clDist:= JOIN(AllOffset, gInst,LEFT.number=RIGHT.number AND LEFT.id=RIGHT.id, TRANSFORM(Types.l_result, SELF.conf:=LEFT.conf/RIGHT.tot, SELF:=LEFT), LOCAL);
+      RETURN clDist;
     END;
+    // Classification function for continuous independent values and model
+    EXPORT ClassifyC(DATASET(Types.NumericField) Indep,DATASET(Types.NumericField) mod) := FUNCTION
+      // get class probabilities for each instance
+      dClass:= ClassProbDistribC(Indep, mod);
+      // select the class with greatest probability for each instance
+      sClass := SORT(dClass, id, -conf, LOCAL);
+      finalClass:=DEDUP(sClass, id, LOCAL);
+      RETURN finalClass;
+     END;
   END; // NaiveBayes Module
 
 /*
@@ -566,7 +584,6 @@ END;
 			Ind := DISTRIBUTE(Indep,HASH(id));
 			l_result note(Ind le,mo ri) := TRANSFORM
 			  SELF.conf := le.value*ri.w;
-				SELF.closest_conf := 0;
 				SELF.number := ri.class_number;
 				SELF.value := 0;
 				SELF.id := le.id;
@@ -681,7 +698,6 @@ EXPORT Logistic_sparse(REAL8 Ridge=0.00001, REAL8 Epsilon=0.000000001, UNSIGNED2
 		  SELF.id := le.x;
 			SELF.number := le.y;
 			SELF.conf := ABS(le.value-0.5);
-			SELF.closest_conf := 0;
 		END;
 		RETURN PROJECT(sigmoid,tr(LEFT));
 	END;
@@ -1017,7 +1033,6 @@ EXPORT Logistic_sparse(REAL8 Ridge=0.00001, REAL8 Epsilon=0.000000001, UNSIGNED2
           SELF.id := le.x;
             SELF.number := le.y;
             SELF.conf := ABS(le.value-0.5);
-            SELF.closest_conf := 0;
         END;
         
         RETURN PROJECT(sigmoid,tr(LEFT));

--- a/ML/Lazy.ecl
+++ b/ML/Lazy.ecl
@@ -1,4 +1,4 @@
-IMPORT ML;
+﻿IMPORT ML;
 IMPORT * FROM $;
 /*
 Instance-based learning
@@ -8,10 +8,7 @@ instead of performing explicit generalization, compare new problem instances wit
 which have been stored in memory. Instance-based learning is a kind of lazy learning.
 */
 EXPORT Lazy:= MODULE
-  SHARED l_result := RECORD(Types.DiscreteField)
-    REAL8 conf;  // Confidence - high is good
-    REAL8 closest_conf:=0;
-  END;
+  SHARED l_result := Types.l_result;
   // General KNN Classifier
   EXPORT KNN(CONST Types.t_count NN_count=5) := MODULE,VIRTUAL
     EXPORT MajorityVote(DATASET(NearestNeighborsSearch.NN) NNeighbors ,DATASET(Types.DiscreteField) depData):= FUNCTION

--- a/ML/Tests/Explanatory/BinaryC45Horizontal.ecl
+++ b/ML/Tests/Explanatory/BinaryC45Horizontal.ecl
@@ -13,7 +13,6 @@ tmodel:= trainer1.Model(tmod);
 OUTPUT(SORT(tmodel, node_id, new_node_id), ALL, NAMED('TreeModel'));
 results1:= trainer1.ClassifyC(indepData, tmod);
 OUTPUT(results1, ALL, NAMED('ClassificationResults'));
-OUTPUT(TABLE(results1, {closest_conf, cnt:= COUNT(GROUP)}, closest_conf), NAMED('FinalNodeAssig1'));
 results11:= Classify.Compare(PROJECT(depData, TRANSFORM(Types.DiscreteField,SELF.number:=1, SELF:=LEFT)), results1);
 OUTPUT(results11.CrossAssignments, NAMED('CrossAssig1'));
 OUTPUT(results11.RecallByClass, NAMED('RecallByClass1'));

--- a/ML/Tests/Explanatory/BinaryC45Iris.ecl
+++ b/ML/Tests/Explanatory/BinaryC45Iris.ecl
@@ -176,7 +176,6 @@ OUTPUT(SORT(tmodel, -node_id, -new_node_id), ALL, NAMED('TreeModel'));
 //Classification Phase
 results1:= trainer1.ClassifyC(indepData, tmod);
 OUTPUT(results1, NAMED('ClassificationResults'), ALL);
-OUTPUT(TABLE(results1, {closest_conf, cnt:= COUNT(GROUP)}, closest_conf), NAMED('FinalNodeAssig1'));
 results11:= Classify.Compare(PROJECT(depData, TRANSFORM(Types.DiscreteField,SELF.number:=1, SELF:=LEFT)), results1);
 OUTPUT(SORT(results11.CrossAssignments, c_actual, c_modeled), NAMED('CrossAssig1'), ALL);
 OUTPUT(results11.RecallByClass, NAMED('RecallByClass1'));

--- a/ML/Tests/Explanatory/Classify.ecl
+++ b/ML/Tests/Explanatory/Classify.ecl
@@ -24,11 +24,10 @@ D2 := ML.Discretize.ByRounding(D1);
 BayesModule := ML.Classify.NaiveBayes;
 
 TestModule := BayesModule.TestD(D2(Number<=3),D2(Number=4));
-TestModule.Raw;
 TestModule.CrossAssignments;
 TestModule.PrecisionByClass;
-TestModule.Headline;
+TestModule.Accuracy;
 
 Model := BayesModule.LearnD(D2(Number<=3),D2(Number=4));
 Results := BayesModule.ClassifyD(D2(Number<=3),Model);
-Results
+Results;

--- a/ML/Tests/Explanatory/Discretize.ecl
+++ b/ML/Tests/Explanatory/Discretize.ecl
@@ -38,11 +38,10 @@ done := ML.Discretize.Do(o,inst);
 BayesModule := ML.Classify.NaiveBayes;
 
 TestModule := BayesModule.TestD(done(Number<=3),done(Number=4));
-TestModule.Raw;
 TestModule.CrossAssignments;
 TestModule.PrecisionByClass;
-TestModule.Headline;
+TestModule.Accuracy;
 
 Model := BayesModule.LearnD(done(Number<=3),done(Number=4));
 Results := BayesModule.ClassifyD(done(Number<=3),Model);
-Results
+Results;

--- a/ML/Tests/Explanatory/FoldTest.ecl
+++ b/ML/Tests/Explanatory/FoldTest.ecl
@@ -22,7 +22,7 @@ OUTPUT(newDependent, NAMED('Dep3Folds'),ALL);
 OUTPUT(results1.CrossAssignments, NAMED('CA_1'));
 OUTPUT(results1.RecallByClass, NAMED('Rec1'));
 OUTPUT(results1.PrecisionByClass, NAMED('Pre1'));
-OUTPUT(SORT(results1.FP_Rate_ByClass, classifier, class), NAMED('FPR1'));
+OUTPUT(SORT(results1.FP_Rate_ByClass, classifier, c_modeled), NAMED('FPR1'));
 OUTPUT(results1.Accuracy, NAMED('Acc1'));
 
 // Example 2:
@@ -54,7 +54,7 @@ compareAll:= ML.Classify.Compare(depAll, results);
 OUTPUT(compareAll.CrossAssignments, NAMED('CA_2'));
 OUTPUT(compareAll.RecallByClass, NAMED('Rec2'));
 OUTPUT(compareAll.PrecisionByClass, NAMED('Pre2'));
-OUTPUT(SORT(compareAll.FP_Rate_ByClass, classifier, class), NAMED('FPR2'));
+OUTPUT(SORT(compareAll.FP_Rate_ByClass, classifier, c_modeled), NAMED('FPR2'));
 OUTPUT(compareAll.Accuracy, NAMED('Acc2'));
 
 // Example 3:
@@ -93,7 +93,7 @@ OUTPUT(rec_3, NAMED('Rec3'));
 pre_3:= compareCV.PrecisionByClass;
 OUTPUT(pre_3, NAMED('Pre3'));
 fpr_3:= compareCV.FP_Rate_ByClass;
-OUTPUT(SORT(fpr_3, classifier, class), NAMED('FPR3'));
+OUTPUT(SORT(fpr_3, classifier, c_modeled), NAMED('FPR3'));
 acc_3:=compareCV.Accuracy;
 OUTPUT(SORT(acc_3, classifier), NAMED('Acc3'));
 
@@ -101,6 +101,6 @@ OUTPUT(SORT(acc_3, classifier), NAMED('Acc3'));
 OUTPUT(TABLE(ca_3, {c_actual, c_modeled, tot:= SUM(GROUP,cnt)}, c_actual, c_modeled), NAMED('CA_3_sum'));
 OUTPUT(TABLE(rec_3, {c_actual, tp_avg:= AVE(GROUP,tp_rate)}, c_actual), NAMED('Rec_3_avg'));
 OUTPUT(TABLE(pre_3, {c_modeled, precision_avg:= AVE(GROUP,precision)}, c_modeled), NAMED('pre_3_avg'));
-OUTPUT(TABLE(fpr_3, {class, fpr_avg:= AVE(GROUP, fp_rate)}, class), NAMED('fpr_3_avg'));
+OUTPUT(TABLE(fpr_3, {c_modeled, fpr_avg:= AVE(GROUP, fp_rate)}, c_modeled), NAMED('fpr_3_avg'));
 OUTPUT(AVE(acc_3, accuracy), NAMED('accuracy_3_avg'));
 

--- a/ML/Tests/Explanatory/KNN_KDTree.ecl
+++ b/ML/Tests/Explanatory/KNN_KDTree.ecl
@@ -1,4 +1,4 @@
-IMPORT * FROM ML;
+﻿IMPORT * FROM ML;
 IMPORT ML.Tests.Explanatory as TE;
 
 Depth:= 10;
@@ -22,15 +22,13 @@ depTest := ML.Discretize.ByRounding(pr_depT);
 iknn:= Lazy.KNN_KDTree(5);
 
 TestModule:=  iknn.TestC(IndepTest, depTest);
-TestModule.Raw;
 TestModule.CrossAssignments;
 TestModule.PrecisionByClass;
-TestModule.Headline;
+TestModule.Accuracy;
 
 computed:=  iknn.ClassifyC(IndepData, depData, IndepTest);
 Comparison:=  ML.Classify.Compare(depTest, computed);
 computed;
-Comparison.Raw;
 Comparison.CrossAssignments;
 Comparison.PrecisionByClass;
-Comparison.Headline;
+Comparison.Accuracy;

--- a/ML/Tests/Explanatory/classify_logistic.ecl
+++ b/ML/Tests/Explanatory/classify_logistic.ecl
@@ -29,10 +29,9 @@ Model4 := LogisticModule.LearnCS(flds0(Number<=2),flds(Number=4));
 Model4;
 
 TestModule := LogisticModule.TestD(flds(Number<=2),flds(Number>=3));
-TestModule.Raw;
 TestModule.CrossAssignments;
 TestModule.PrecisionByClass;
-TestModule.Headline;
+TestModule.Accuracy;
 
 LogisticModule.ClassifyC(flds0(Number<=2),Model3);
 LogisticModule.ClassifyC(flds0(Number<=2),Model4);

--- a/ML/Trees.ecl
+++ b/ML/Trees.ecl
@@ -918,7 +918,6 @@ EXPORT Trees := MODULE
       SELF.number	:= 1;
       SELF.value	:= r.value;
       SELF.conf		:= 0;		// added to fit in l_result, not used so far
-      SELF.closest_conf:= l.new_node_id;	// store final leaf node id, will use it in class distribution
     END;
     RETURN JOIN(splitData, leafs, LEFT.new_node_id = RIGHT.node_id, final_class(LEFT, RIGHT), LOOKUP);
   END;

--- a/ML/Types.ecl
+++ b/ML/Types.ecl
@@ -31,7 +31,6 @@ EXPORT DiscreteField := RECORD
 
 EXPORT l_result := RECORD(DiscreteField)
   REAL8 conf;  // Confidence - high is good
-  REAL8 closest_conf;
   END;
 
 EXPORT ItemElement := RECORD


### PR DESCRIPTION
Naive Bayes:
- Add Class Probability Distribution (CPD) to discrete and continuous NB
- NB CPD now used to calculate ROC AUC statistic for model comparison
- ClassifyD and ClassifyC use CPD to calculate final class
Classify.ecl
- Delete Raw function, CrossAssigment delivers wiser aggregation results.
- Delete HeadLine function, Accuracy is the commonly used term.
- Delete closest_conf from l_results, only was used in NB classication stage, not anymore.
- Clean all the ecl-ml modules referring to Raw, HeadLine or closest_conf.