### PR TITLE
Ml 242 LibSVM Support

### DIFF
--- a/ML/Classify.ecl
+++ b/ML/Classify.ecl
@@ -3,6 +3,7 @@ IMPORT * FROM $;
 IMPORT $.Mat;
 IMPORT * FROM ML.Types;
 IMPORT PBblas;
+IMPORT ML.SVM;
 Layout_Cell := PBblas.Types.Layout_Cell;
 
 /*
@@ -1471,4 +1472,90 @@ Configuration Input
     END;
     RETURN ITERATE(rocPoints, rocArea(LEFT, RIGHT));
   END;
+
+  // Support Vector Machine.
+  //  see https://en.wikipedia.org/wiki/Support_vector_machine
+  // Use the SVM attributes directly for scaling and grid search.  This
+  //module acts as a facade to the actual SVM attributes and provides only
+  //the interface and capabilities defined for the Classify abstract.
+  //
+  // The inputs are:
+  /*  svm_type : set type of SVM, SVM.Types.SVM_Type enum
+              C_SVC    (multi-class classification)
+              NU_SVC   (multi-class classification)
+              ONE_CLASS SVM
+              EPSILON_SVR  (regression)
+              NU_SVR   (regression)
+      kernel_type : set type of kernel function, SVM.Types.Kernel_Type enum
+              LINEAR: u'*v
+              POLY:   polynomial,  (gamma*u'*v + coef0)^degree
+              RBF:    radial basis function: exp(-gamma*|u-v|^2)
+              SIGMOID: tanh(gamma*u'*v + coef0)
+              PRECOMPUTED: precomputed kernel (kernel values in training_set_file)
+      degree : degree in kernel function for POLY
+      gamma  : gamma in kernel function for POLY, RBF, and SIGMOID
+      coef0  : coef0 in kernel function for POLY, SIGMOID
+      cost   : the parameter C of C-SVC, epsilon-SVR, and nu-SVR
+      eps    : the epsilon for stopping
+      nu     : the parameter nu of nu-SVC, one-class SVM, and nu-SVR
+      p      : the epsilon in loss function of epsilon-SVR
+      shrinking : whether to use the shrinking heuristics, default TRUE
+  */
+  // The LibSVM development package must be installed on your cluster!
+  EXPORT SVM(SVM.Types.SVM_Type svm_type, SVM.Types.Kernel_Type kernel_type,
+             INTEGER4 degree, REAL8 gamma, REAL8 coef0, REAL8 cost, REAL8 eps,
+             REAL8 nu, REAL8 p, BOOLEAN shrinking) := MODULE(DEFAULT)
+    SVM.Types.Training_Parameters
+    makeParm(UNSIGNED4 dep_field, SVM.Types.SVM_Type svm_type,
+             SVM.Types.Kernel_Type kernel_type,
+             INTEGER4 degree, REAL8 gamma, REAL8 coef0, REAL8 cost,
+             REAL8 eps, REAL8 nu, REAL8 p, BOOLEAN shrinking) := TRANSFORM
+      SELF.id := dep_field;
+      SELF.svmType := svm_type;
+      SELF.kernelType := kernel_type;
+      SELF.degree := degree;
+      SELF.gamma := gamma;
+      SELF.coef0 := coef0;
+      SELF.C := cost;
+      SELF.eps := eps;
+      SELF.nu := nu;
+      SELF.p := p;
+      SELF.shrinking := shrinking;
+      SELF.prob_est := FALSE;
+      SELF := [];
+    END;
+    SHARED Training_Param(UNSIGNED4 df) := ROW(makeParm(df, svm_type,
+                                          kernel_type, degree,
+                                          gamma, coef0, cost, eps, nu,
+                                          p, shrinking));
+    // Learn from continuous data
+    EXPORT LearnC(DATASET(Types.NumericField) Indep,
+                  DATASET(Types.DiscreteField) Dep) := FUNCTION
+      depc := PROJECT(Dep, Types.NumericField);
+      inst_data := SVM.Converted.ToInstance(Indep, Depc);
+      dep_field := dep[1].number;
+      tp := DATASET(Training_Param(dep_field));
+      mdl := SVM.train(tp, inst_data);
+      nf_mdl := SVM.Converted.FromModel(Base, mdl);
+      RETURN nf_mdl; // All classifiers serialized to numeric field format
+    END;
+    // Learn from discrete data uses DEFAULT implementation
+    // Classify continuous data - using a prebuilt model
+    EXPORT ClassifyC(DATASET(Types.NumericField) Indep,
+                     DATASET(Types.NumericField) mod) := FUNCTION
+      inst_data := SVM.Converted.ToInstance(Indep);
+      mdl := SVM.Converted.ToModel(mod);
+      pred := SVM.predict(mdl, inst_data).Prediction;
+      // convert to standard form
+      l_result cvt(SVM.Types.SVM_Prediction p) := TRANSFORM
+        SELF.id := p.rid;
+        SELF.number := p.id; // model ID is the dependent var field ID
+        SELF.value := p.predict_y;
+        SELF.conf := 0.5; // no confidence measures
+      END;
+      rslt := PROJECT(pred, cvt(LEFT));
+      RETURN rslt;
+    END;
+    // Classify discrete data - uses DEFAULT implementation
+  END; // SVM
 END;

--- a/ML/SVM/Converted.ecl
+++ b/ML/SVM/Converted.ecl
@@ -1,0 +1,201 @@
+// Converted to and from SVM and generic formats for ML/Classify
+IMPORT ML;
+IMPORT ML.SVM;
+IMPORT ML.Types AS ML_Types;
+EXPORT Converted := MODULE
+  //Instance data
+  // Don't need from instance.  This can be a one-way trip.
+  dummy := DATASET([], ML_Types.NumericField);
+  EXPORT ToInstance(DATASET(ML_Types.NumericField) Ind,
+                    DATASET(ML_Types.NumericField) Dep=dummy) := FUNCTION
+    g_i := GROUP(SORT(Ind, id, number), id);
+    SVM.Types.SVM_Feature cvtF(ML_Types.NumericField nf) := TRANSFORM
+      SELF.nominal := nf.number;
+      SELF.v := nf.value;
+    END;
+    SVM.Types.SVM_Instance rollNF(ML_Types.NumericField f,
+                                  DATASET(ML_Types.NumericField) ds) := TRANSFORM
+      SELF.rid := f.id;
+      SELF.y := 0;
+      SELF.max_value := MAX(ds,value);
+      SELF.x := PROJECT(ds, cvtF(LEFT));
+    END;
+    indy := ROLLUP(g_i, GROUP, rollNF(LEFT, ROWS(LEFT)));
+    SVM.Types.SVM_Instance getD(SVM.Types.SVM_Instance i, ML_Types.NumericField d):=TRANSFORM
+      SELF.y := d.value;
+      SELF := i;
+    END;
+    rslt := JOIN(indy, dep, LEFT.rid=RIGHT.id, getD(LEFT,RIGHT),
+                 LEFT OUTER, LIMIT(1,FAIL));
+    RETURN rslt;
+  END;  // to instance data
+  // Model data
+  SHARED Field_ID := 1;
+  SHARED s_type_id:= Field_ID + 1;        // 2
+  SHARED k_type_id:= s_type_id + 1;       // 3
+  SHARED degree_id:= k_type_id + 1;       // 4
+  SHARED gamma_id := degree_id + 1;       // 5
+  SHARED coef0_id := gamma_id + 1;        // 6
+  SHARED k_id := coef0_id + 1;            // 7
+  SHARED l_id := k_id + 1;                // 8
+  SHARED pairs_a_id := l_id + 1;          // 9
+  SHARED pairs_b_id := pairs_a_id + 1;    //10
+  SHARED n_label_id := pairs_b_id + 1;    //11
+  SHARED n_sv_id := n_label_id + 1;       //12
+  SHARED lf_id := n_sv_id; //last field id
+  UNSIGNED4 get_SV_Count(DATASET(SVM.Types.SVM_SV) sv) := FUNCTION
+    sv_count := COUNT(sv);
+    features := SUM(sv, COUNT(sv.features));
+    RETURN 2*sv_count + 2*features;
+  END;
+  SVM.Types.R8Entry norm_feature(SVM.Types.SVM_Feature f, UNSIGNED c):=TRANSFORM
+    SELF.v := CHOOSE(c, (REAL8)f.nominal, f.v);
+  END;
+  Work1 := RECORD
+    DATASET(SVM.Types.R8Entry) d;
+  END;
+  Work1 cvt_2_r8(SVM.Types.SVM_SV s) := TRANSFORM
+    SELF.d := DATASET([{2*(COUNT(s.features)+1)},{s.v_ord}], SVM.Types.R8Entry)
+            + NORMALIZE(s.features, 2, norm_feature(LEFT, COUNTER));
+  END;
+  SVM.Types.R8Entry cvt_sv(DATASET(SVM.Types.SVM_SV) sv) := FUNCTION
+    w1 := PROJECT(sv, cvt_2_r8(LEFT));
+    rslt := NORMALIZE(w1, LEFT.d, TRANSFORM(SVM.Types.R8Entry, SELF.v:=RIGHT.v));
+    RETURN rslt;
+  END;
+
+  //
+  EXPORT FromModel(UNSIGNED id_base, DATASET(SVM.Types.Model) mdl) := FUNCTION
+    ML_Types.NumericField getField(SVM.Types.Model m, UNSIGNED c) := TRANSFORM
+      SELF.id := id_base + m.id;
+      SELF.number := c;
+      SELF.value := CHOOSE(c, (REAL8) m.id, (REAL8) m.svmType,
+                              (REAL8) m.kernelType, (REAL8) m.degree,
+                              m.gamma, m.coef0, (REAL8) m.k, (REAL8) m.l,
+                              (REAL8) COUNT(m.probA), (REAL8) COUNT(m.probB),
+                              (REAL8) COUNT(m.labels), (REAL8) get_SV_Count(m.sv));
+    END;
+    fixed_part := NORMALIZE(mdl, lf_id-field_id+1, getField(LEFT,COUNTER));
+    ML_Types.NumericField normSV(SVM.Types.Model m, SVM.Types.R8Entry e, UNSIGNED8 c) := TRANSFORM
+      SELF.id := id_base + m.id;
+      SELF.number := lf_id + c;
+      SELF.value  := e.v;
+    END;
+    sv_part := NORMALIZE(mdl, cvt_SV(LEFT.sv), normSV(LEFT, RIGHT, COUNTER));
+    ML_Types.NumericField normR8(SVM.Types.Model m, SVM.Types.R8Entry d,
+                                 UNSIGNED c, UNSIGNED4 base) := TRANSFORM
+      SELF.id := id_base + m.id;
+      SELF.number := base + c;
+      SELF.value := d.v;
+    END;
+    coef_part := NORMALIZE(mdl, LEFT.sv_coef,
+                          normR8(LEFT, RIGHT, COUNTER,
+                                 lf_id + get_SV_Count(LEFT.sv)));
+    rho_part  := NORMALIZE(mdl, LEFT.rho,
+                          normR8(LEFT, RIGHT, COUNTER,
+                                lf_id + get_SV_Count(LEFT.sv) + COUNT(LEFT.sv_coef)));
+    probA_part:= NORMALIZE(mdl, LEFT.probA,
+                           normR8(LEFT, RIGHT, COUNTER,
+                                  lf_id + get_SV_Count(LEFT.sv) + COUNT(LEFT.sv_coef)
+                                  + COUNT(LEFT.rho) ));
+    probB_part:= NORMALIZE(mdl, LEFT.probB,
+                           normR8(LEFT, RIGHT, COUNTER,
+                                  lf_id + get_SV_Count(LEFT.sv) + COUNT(LEFT.sv_coef)
+                                  + COUNT(LEFT.rho) + COUNT(LEFT.probA)  ));
+    ML_Types.NumericField normI4(SVM.Types.Model m, SVM.Types.I4Entry d,
+                                 UNSIGNED c, UNSIGNED4 base) := TRANSFORM
+      SELF.id := id_base + m.id;
+      SELF.number := base + c;
+      SELF.value := (REAL8) d.v;
+    END;
+    lab_part  := NORMALIZE(mdl, LEFT.labels,
+                           normI4(LEFT, RIGHT, COUNTER,
+                                  lf_id + get_SV_Count(LEFT.sv) + COUNT(LEFT.sv_coef)
+                                  + COUNT(LEFT.rho) + COUNT(LEFT.probA)
+                                  + COUNT(LEFT.probB)  ));
+    nsv_part  := NORMALIZE(mdl, LEFT.nSV,
+                           normI4(LEFT, RIGHT, COUNTER,
+                                  lf_id + get_SV_Count(LEFT.sv) + COUNT(LEFT.sv_coef)
+                                  + COUNT(LEFT.rho) + COUNT(LEFT.probA)
+                                  + COUNT(LEFT.probB) + COUNT(LEFT.Labels) ));
+    RETURN fixed_part + sv_part + coef_part + rho_part + probA_part
+                + probB_part + lab_part + nsv_part;
+  END;
+  //
+  Exp_NF := RECORD(ML_Types.NumericField)
+    UNSIGNED feature;
+    UNSIGNED vector;
+  END;
+  Exp_NF mark_xnf(Exp_NF prev, Exp_NF curr) := TRANSFORM
+    SELF.vector := IF(curr.number>prev.vector,
+                      curr.number+(UNSIGNED)curr.value-1,
+                      prev.vector);
+    SELF.feature:= IF(curr.number=prev.feature, prev.feature, curr.number+1);
+    SELF := curr;
+  END;
+  SVM.Types.SVM_Feature makeFeature(DATASET(Exp_NF) d) := TRANSFORM
+    SELF.nominal := (INTEGER) d[1].value;
+    SELF.v := d[2].value;
+  END;
+  SVM.Types.SVM_SV roll_xnf(Exp_NF f, DATASET(Exp_NF) ds) := TRANSFORM
+    feature_data := GROUP(CHOOSEN(ds, ALL, 3), feature);
+    SELF.v_ord := (INTEGER) ds[2].value;
+    SELF.features := ROLLUP(feature_data, GROUP, makeFeature(ROWS(LEFT)));
+  END;
+  SVM.Types.R8Entry toR8(ML_Types.NumericField nf) := TRANSFORM
+    SELF.v := nf.value;
+  END;
+  SVM.Types.I4Entry toI4(ML_Types.NumericField nf) := TRANSFORM
+    SELF.v := (INTEGER) nf.value;
+  END;
+  toSV_Dataset(DATASET(ML_Types.NumericField) nf) := FUNCTION
+    x_nf := PROJECT(nf, TRANSFORM(Exp_NF, SELF:=LEFT,SELF:=[]));
+    marked_x := ITERATE(x_nf, mark_xnf(LEFT,RIGHT));
+    group_x := GROUP(marked_x, vector);
+    rslt := ROLLUP(group_x, GROUP, roll_xnf(LEFT, ROWS(LEFT)));
+    RETURN rslt;
+  END;
+  EXPORT ToModel(DATASET(ML_Types.NumericField) mdl) := FUNCTION
+    gs0 := SORT(GROUP(mdl, id, ALL), number);
+    SVM.Types.Model rollModel(DATASET(ML_Types.NumericField) d) := TRANSFORM
+      fixed := DICTIONARY(d(number<=lf_id), {number=>value});
+      nsv := (UNSIGNED) fixed[n_sv_id].value;
+      probA := (UNSIGNED) fixed[pairs_a_id].value;
+      probB := (UNSIGNED) fixed[pairs_b_id].value;
+      labels:= (UNSIGNED) fixed[n_label_id].value;
+      k := (UNSIGNED) fixed[k_id].value;
+      l := (UNSIGNED) fixed[l_id].value;
+      sv_start := lf_id + 1;
+      sv_stop := sv_start + nsv - 1;
+      coef_start := sv_stop + 1;
+      coef_stop := coef_start + (k-1)*l - 1;
+      rho_start := coef_stop + 1;
+      rho_stop := rho_start + (k-1)*k/2 - 1;
+      probA_start := rho_stop + 1;
+      probA_stop := probA_start + probA - 1;
+      probB_start := probA_stop + 1;
+      probB_stop := probB_start + probB - 1;
+      label_start := probB_stop + 1;
+      label_stop := label_start + labels - 1;
+      nSV_start := label_stop + 1;
+      nSV_stop := nSV_start + labels - 1;
+      SELF.id := (UNSIGNED) fixed[Field_ID].value;
+      SELF.svmType := (UNSIGNED1) fixed[s_type_id].value;
+      SELF.kernelType := (UNSIGNED1) fixed[k_type_id].value;
+      SELF.degree := (UNSIGNED) fixed[degree_id].value;
+      SELF.coef0 := fixed[coef0_id].value;
+      SELF.gamma := fixed[gamma_id].value;
+      SELF.k := k;
+      SELF.l := l;
+      SELF.sv := toSV_Dataset(d(number BETWEEN sv_start AND sv_stop));
+      SELF.sv_coef := PROJECT(d(number BETWEEN coef_start AND coef_stop), toR8(LEFT));
+      SELF.rho := PROJECT(d(number BETWEEN rho_start AND rho_stop), toR8(LEFT));
+      SELF.probA := PROJECT(d(number BETWEEN probA_start AND probA_stop), toR8(LEFT));
+      SELF.probB := PROJECT(d(number BETWEEN probB_start AND probB_stop), toR8(LEFT));
+      SELF.labels:= PROJECT(d(number BETWEEN label_start AND label_stop), toI4(LEFT));
+      SELF.nSV := PROJECT(d(number BETWEEN nSV_start AND nSV_stop), toI4(LEFT));
+    END;
+    rslt := ROLLUP(gs0, GROUP, rollModel(ROWS(LEFT)));
+    RETURN rslt;
+  END;
+END;

--- a/ML/SVM/LibSVM/Constants.ecl
+++ b/ML/SVM/LibSVM/Constants.ecl
@@ -1,0 +1,3 @@
+EXPORT Constants := MODULE
+  EXPORT LibSVM_BadParm := 9000;
+END;

--- a/ML/SVM/LibSVM/Converted.ecl
+++ b/ML/SVM/LibSVM/Converted.ecl
@@ -1,0 +1,92 @@
+//Convert data to SVM_Problem format
+//
+//Sources include SVM Problem data from LibSVM sample data files,
+//and ML NumericField format datasets.
+IMPORT ML.SVM.LibSVM.Types;
+IMPORT ML.SVM.Types AS SVM_Types;
+IMPORT STD;
+// aliases for shorter names
+ECL_LibSVM_Problem := Types.ECL_LibSVM_Problem;
+R8Entry := Types.R8Entry;
+LibSVM_Node := Types.LibSVM_Node;
+SVM_Feature := SVM_Types.SVM_Feature;
+SVM_Instance := SVM_Types.SVM_Instance;
+EXPORT Converted := MODULE
+  // MAke Instance data from a text file in LibSVM test data format
+  EXPORT DATASET(SVM_Instance) LIBSVMDATA2Instance(STRING fname):=FUNCTION
+    svmread_format := RECORD
+      STRING line;
+      UNSIGNED8 fpos{VIRTUAL(fileposition)};
+    END;
+    StringEntry := RECORD
+      STRING v;
+    END;
+    ds := DATASET(fname, svmread_format, CSV(SEPARATOR([])));
+    // convert the file
+    F_Plus := RECORD(SVM_Feature)
+      BOOLEAN good;
+      BOOLEAN flag;
+    END;
+    F_Plus makeFeature(STRING pair) := TRANSFORM
+      pair_set := STD.Str.SplitWords(pair, ':');
+      SELF.nominal := (INTEGER) pair_set[1];
+      SELF.v:= (REAL8) pair_set[2];
+      SELF.good := TRUE;
+      SELF.flag := TRUE;  // distinguish first call to iterate
+    END;
+    F_Plus checkAscending(F_Plus prev, F_Plus curr) := TRANSFORM
+      SELF.good := (NOT prev.flag AND curr.nominal >= 0)
+                OR (curr.nominal >= 0 AND curr.nominal > prev.nominal);
+      SELF := curr;
+    END;
+    STRING delims := ' \t\r\n';
+    SVM_Instance cvtInstance(svmread_format lr) := TRANSFORM
+      preped := STD.Str.substituteincluded(lr.line, delims, '|');
+      elems := STD.Str.SplitWords(preped, '|');
+      elems_ds := DATASET(elems, StringEntry);
+      w_x0 := PROJECT(elems_ds[2..], makeFeature(LEFT.v));
+      w_x1 := ITERATE(w_x0, checkAscending(LEFT,RIGHT));
+      w_x2 := ASSERT(w_x1, good, 'Indx out of order, label ' + elems[1], FAIL);
+      SELF.y := (REAL8)elems[1];
+      SELF.max_value:= MAX(w_x2, v);
+      SELF.x := PROJECT(w_x2, SVM_Feature);
+      SELF.rid := lr.fpos;    // use the file position as identifier
+    END;
+    problem := PROJECT(ds, cvtInstance(LEFT));
+    RETURN problem;
+  END;
+  //
+  // Make a LibSVM Problem file from an Instance file.  This
+  //will be a single record file.
+  EXPORT DATASET(ECL_LibSVM_Problem)
+         Instance2Problem(DATASET(SVM_Instance) ds) := FUNCTION
+    LibSVM_Node lastNode() := TRANSFORM
+      SELF.indx := -1;
+      SELF.value := 0.0;
+    END;
+    LibSVM_Node cvtFeature(SVM_Feature feature) := TRANSFORM
+      SELF.indx := feature.nominal;
+      SELF.value := feature.v;
+    END;
+    ECL_LibSVM_Problem cvtInstance(SVM_Instance instance) := TRANSFORM
+      SELF.elements := COUNT(instance.x) + 1;  //include -1 row
+      SELF.entries := 1;
+      SELF.features := MAX(instance.x, nominal);
+      SELF.max_value := instance.max_value;
+      SELF.y := DATASET([{instance.y}], R8Entry);
+      SELF.x := PROJECT(SORT(instance.x, nominal), cvtFeature(LEFT))
+              & DATASET(1, lastNode());
+    END;
+    es := PROJECT(ds, cvtInstance(LEFT));
+    ECL_LibSVM_Problem r(ECL_LibSVM_Problem c, ECL_LibSVM_Problem i):=TRANSFORM
+      SELF.elements := c.elements + i.elements;
+      SELF.entries := c.entries + i.entries;
+      SELF.features:= MAX(c.features, i.features);
+      SELF.max_value:= MAX(c.max_value, i.max_value);
+      SELF.y := c.y & i.y;
+      SELF.x := c.x & i.x;
+    END;
+    prob := ROLLUP(es, TRUE, r(LEFT,RIGHT));
+    RETURN prob;
+  END;
+END;

--- a/ML/SVM/LibSVM/LibSVM_Version.ecl
+++ b/ML/SVM/LibSVM/LibSVM_Version.ecl
@@ -1,0 +1,12 @@
+// The version from LibSVM
+INTEGER4 getVersion() := BEGINC++
+extern "C" {
+  #include <libsvm/svm.h>
+}
+#option library svm
+#option pure
+#body
+  return libsvm_version;
+ENDC++;
+
+EXPORT LibSVM_Version := getVersion();

--- a/ML/SVM/LibSVM/Test/file_conversion.ecl
+++ b/ML/SVM/LibSVM/Test/file_conversion.ecl
@@ -41,7 +41,9 @@ Expanded_Prob expand(ECL_LibSVM_Problem p) := TRANSFORM
   SELF := p;
 END;
 xproblem_data := PROJECT(problem_data, expand(LEFT));
+OUTPUT(xproblem_data, NAMED('Problem_Data'));
 
+// Decompose problem data for easier display
 Head_Prob := RECORD
   UNSIGNED4 elements;
   INTEGER4 entries;

--- a/ML/SVM/LibSVM/Test/file_conversion.ecl
+++ b/ML/SVM/LibSVM/Test/file_conversion.ecl
@@ -1,0 +1,71 @@
+//Check the file conversion routines
+//export file_conversion := 'todo';
+IMPORT ML.SVM;
+IMPORT ML.SVM.LibSVM;
+
+ECL_LibSVM_Problem := LibSVM.Types.ECL_LibSVM_Problem;
+LibSVM_Node := LibSVM.Types.LibSVM_Node;
+R8Entry := LibSVM.Types.R8Entry;
+fileName := '~thor::libsvm_data::heart_scale_csv';
+rawInput := DATASET(fileName, {STRING line}, CSV(SEPARATOR([])));
+OUTPUT(CHOOSEN(rawInput, 300), ALL, NAMED('raw_input'));
+
+instance_data := LibSVM.Converted.LIBSVMDATA2Instance(fileName);
+OUTPUT(CHOOSEN(instance_data, 300), ALL, NAMED('Instance_data'));
+
+problem_data := LibSVM.Converted.Instance2Problem(instance_data);
+
+
+LibSVM_Node_Exp := RECORD(LibSVM_Node)
+  UNSIGNED4 entry;
+END;
+LibSVM_Node_Exp cvt(LibSVM_Node n) := TRANSFORM
+  SELF.entry := 0;
+  SELF := n;
+END;
+LibSVM_Node_Exp mark(LibSVM_Node_Exp prev, LibSVM_Node_Exp curr) := TRANSFORM
+  newEntry := prev.entry=0 OR prev.indx=-1;
+  SELF.entry := IF(newEntry, prev.entry+1, prev.entry);
+  SELF := curr;
+END;
+Expanded_Prob := RECORD
+    UNSIGNED4 elements;
+    INTEGER4 entries;
+    UNSIGNED4 features;
+    REAL8 max_value;
+    DATASET(R8Entry, COUNT(SELF.entries)) y;
+    DATASET(LibSVM_Node_Exp, COUNT(SELF.elements)) x;
+END;
+Expanded_Prob expand(ECL_LibSVM_Problem p) := TRANSFORM
+  SELF.x := ITERATE(PROJECT(p.x,cvt(LEFT)), mark(LEFT,RIGHT));
+  SELF := p;
+END;
+xproblem_data := PROJECT(problem_data, expand(LEFT));
+
+Head_Prob := RECORD
+  UNSIGNED4 elements;
+  INTEGER4 entries;
+  UNSIGNED4 features;
+  REAL8 max_value;
+END;
+Flat_Prob := RECORD
+  UNSIGNED4 entry;
+  UNSIGNED4 elements;
+  REAL8 y;
+  DATASET(LibSVM_Node, COUNT(SELF.elements)) x;
+END;
+Head_Prob extHead(Expanded_Prob p) := TRANSFORM
+  SELF := p;
+END;
+problem_head := PROJECT(xproblem_data, extHead(LEFT));
+OUTPUT(problem_head, NAMED('problem_head'));
+
+Flat_Prob extNode(Expanded_Prob p, UNSIGNED4 c) := TRANSFORM
+  these_elements := p.x(entry=c);
+  SELF.entry := c;
+  SELF.y := p.y[c].v;
+  SELF.elements := COUNT(these_elements);
+  SELF.x := PROJECT(these_elements, LibSVM_Node);
+END;
+prob_lines := NORMALIZE(xproblem_data, LEFT.entries, extNode(LEFT,COUNTER));
+OUTPUT(CHOOSEN(prob_lines, 300), ALL, NAMED('prob_lines'));

--- a/ML/SVM/LibSVM/Test/run_heart_scale.ecl
+++ b/ML/SVM/LibSVM/Test/run_heart_scale.ecl
@@ -1,5 +1,6 @@
 //The test of LibSVM implementation using the heart scale dataset
 //export run_heart_scale := 'todo';
+IMPORT ML;
 IMPORT ML.SVM;
 IMPORT ML.SVM.LibSVM;
 
@@ -36,6 +37,9 @@ OUTPUT(SORT(score_data, id), NAMED('Scores'));
 
 //Now run model
 heart_model := SVM.train(heart_parms, instance_data);
+OUTPUT(heart_model, NAMED('Full_Heart_Model'));
+
+//Decompose model for easier display
 Model_Head := RECORD
   SVM.Types.Model_ID id;
   SVM.LibSVM.Types.LibSVM_Type svmType;
@@ -102,6 +106,7 @@ OUTPUT(heart_labels, NAMED('Heart_Label'));
 heart_nSV := PROJECT(heart_model, extractI4(LEFT, 2));
 OUTPUT(heart_nSV, NAMED('heart_nSV'));
 
+//Predictions
 heart_pred := SVM.Predict(heart_model, instance_data).Prediction;
 OUTPUT(CHOOSEN(heart_pred, 100), NAMED('Detail_pred'));
 Raw_Result := RECORD

--- a/ML/SVM/LibSVM/Test/run_heart_scale.ecl
+++ b/ML/SVM/LibSVM/Test/run_heart_scale.ecl
@@ -102,7 +102,7 @@ OUTPUT(heart_labels, NAMED('Heart_Label'));
 heart_nSV := PROJECT(heart_model, extractI4(LEFT, 2));
 OUTPUT(heart_nSV, NAMED('heart_nSV'));
 
-heart_pred := SVM.Predict(heart_model, instance_data);
+heart_pred := SVM.Predict(heart_model, instance_data).Prediction;
 OUTPUT(CHOOSEN(heart_pred, 100), NAMED('Detail_pred'));
 Raw_Result := RECORD
   heart_pred.rid;

--- a/ML/SVM/LibSVM/Test/run_heart_scale.ecl
+++ b/ML/SVM/LibSVM/Test/run_heart_scale.ecl
@@ -1,0 +1,116 @@
+//The test of LibSVM implementation using the heart scale dataset
+//export run_heart_scale := 'todo';
+IMPORT ML.SVM;
+IMPORT ML.SVM.LibSVM;
+
+//Training_Parameters := SVM.Types.Training_Parameters;
+
+fileName := '~thor::libsvm_data::heart_scale_csv';
+instance_data := LibSVM.Converted.LIBSVMDATA2Instance(fileName);
+OUTPUT(instance_data, NAMED('Instance'));
+
+SVM.Types.Training_Parameters base(UNSIGNED c) := TRANSFORM
+  SELF.svmType := LibSVM.Types.LibSVM_Type.C_SVC;
+  SELF.kernelType := LibSVM.Types.LibSVM_Kernel.RBF;
+  SELF.degree := 3;
+  SELF.gamma := 0.0;
+  SELF.coef0 := 0.0;
+  SELF.nu := 0.5;
+  SELF.C := 1.0;
+  SELF.eps := 0.001;
+  SELF.p := 0.1;
+  SELF.shrinking := 1;
+  SELF.prob_est := 0;
+  SELF.nr_weight := 0;
+  SELF.lbl := DATASET([], SVM.Types.I4Entry);
+  SELF.weight := DATASET([], SVM.Types.R8Entry);
+  SELF.id := c;
+END;
+heart_parms := DATASET(1, base(COUNTER));
+
+OUTPUT(LibSVM.LibSVM_Version, NAMED('Version'));
+
+score_data := SVM.cross_validate(heart_parms, instance_data, 5);
+OUTPUT(SORT(score_data, id), NAMED('Scores'));
+
+
+//Now run model
+heart_model := SVM.train(heart_parms, instance_data);
+Model_Head := RECORD
+  SVM.Types.Model_ID id;
+  SVM.LibSVM.Types.LibSVM_Type svmType;
+  SVM.LibSVM.Types.LibSVM_Kernel kernelType;
+  INTEGER4 degree;    // for Poly
+  REAL8 gamma;        // for Poly, RBF, Sigmoid
+  REAL8 coef0;        // for Poly, Sigmoid
+  UNSIGNED4 k;  // number of classes
+  UNSIGNED4 l;  // number of support vectors
+END;
+heart_head := PROJECT(heart_model, Model_Head);
+OUTPUT(heart_head, NAMED('Heart_Head'));
+Model_SV := RECORD
+  SVM.Types.Model_ID id;
+  UNSIGNED4 v_ord;
+  DATASET(SVM.Types.SVM_Feature) features;
+END;
+Model_SV normNodes(SVM.Types.Model model,
+                     SVM.Types.SVM_SV sv) := TRANSFORM
+  SELF.id := model.id;
+  SELF.v_ord := sv.v_ord;
+  SELF.features := sv.features;
+END;
+heart_sv := NORMALIZE(heart_model, LEFT.sv, normNodes(LEFT, RIGHT));
+OUTPUT(heart_sv, NAMED('Heart_SV'));
+
+Model_R8 := RECORD
+  SVM.Types.Model_ID id;
+  UNSIGNED4 c;
+  REAL8 set_sum;
+  DATASET(SVM.LibSVM.Types.R8Entry) ds;
+END;
+Model_R8 extractR8(SVM.Types.Model model, UNSIGNED fld) := TRANSFORM
+  ds := CHOOSE(fld, model.sv_coef, model.rho, model.ProbA, model.probB);
+  SELF.id := model.id;
+  SELF.c  := COUNT(ds);
+  SELF.set_sum := SUM(ds, v);
+  SELF.ds := ds;
+END;
+heart_coef := PROJECT(heart_model, extractR8(LEFT, 1));
+OUTPUT(heart_coef, NAMED('Heart_Coef'));
+heart_rho := PROJECT(heart_model, extractR8(LEFT, 2));
+OUTPUT(heart_rho, NAMED('Heart_rho'));
+heart_probA := PROJECT(heart_model, extractR8(LEFT, 3));
+OUTPUT(heart_probA, NAMED('Heart_probA'));
+heart_probB := PROJECT(heart_model, extractR8(LEFT, 4));
+OUTPUT(heart_probB, NAMED('Heart_probB'));
+
+Model_I4 := RECORD
+  SVM.Types.Model_ID id;
+  UNSIGNED4 c;
+  INTEGER8 set_sum;
+  DATASET(SVM.LibSVM.Types.I4Entry) ds;
+END;
+Model_I4 extractI4(SVM.Types.Model model, UNSIGNED fld) := TRANSFORM
+  ds := CHOOSE(fld, model.labels, model.nSV);
+  SELF.id := model.id;
+  SELF.c := COUNT(ds);
+  SELF.set_sum := SUM(ds, v);
+  SELF.ds := ds;
+END;
+heart_labels := PROJECT(heart_model, extractI4(LEFT, 1));
+OUTPUT(heart_labels, NAMED('Heart_Label'));
+heart_nSV := PROJECT(heart_model, extractI4(LEFT, 2));
+OUTPUT(heart_nSV, NAMED('heart_nSV'));
+
+heart_pred := SVM.Predict(heart_model, instance_data);
+OUTPUT(CHOOSEN(heart_pred, 100), NAMED('Detail_pred'));
+Raw_Result := RECORD
+  heart_pred.rid;
+  UNSIGNED4 correct := IF(heart_pred.predict_y=heart_pred.target_y, 1, 0);
+  UNSIGNED4 wrong := IF(heart_pred.predict_y<>heart_pred.target_y, 1, 0);
+END;
+pred_raw := TABLE(heart_pred, Raw_Result);
+pred_rslt := TABLE(pred_raw, {REAL8 score:=SUM(GROUP,correct)/COUNT(GROUP),
+                              UNSIGNED tot_correct:=SUM(GROUP,correct),
+                              UNSIGNED tot_wrong:=SUM(GROUP,wrong)});
+OUTPUT(pred_rslt, NAMED('Pred_Result'));

--- a/ML/SVM/LibSVM/Types.ecl
+++ b/ML/SVM/LibSVM/Types.ecl
@@ -1,6 +1,7 @@
 // Types for the LibSVM and LibLINEAR implementations
 EXPORT Types := MODULE
   //Interfqce for C++ wrappers, DO NOT ALTER BELOW WITHOUT CHANGING WRAPPERS
+  EXPORT LibSVM_Output:= ENUM(UNSIGNED2, LABEL_ONLY=0, VALUES, PROBS);
   EXPORT LibSVM_Kernel:= ENUM(UNSIGNED2, LINEAR=0, POLY, RBF, SIGMOID, PRECOMPUTED);
   EXPORT LibSVM_Type := ENUM(UNSIGNED2, C_SVC=0, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR);
   EXPORT LibSVM_Node := RECORD  // Sparse 1 based and 0 based for pre-computed

--- a/ML/SVM/LibSVM/Types.ecl
+++ b/ML/SVM/LibSVM/Types.ecl
@@ -1,0 +1,67 @@
+// Types for the LibSVM and LibLINEAR implementations
+EXPORT Types := MODULE
+  //Interfqce for C++ wrappers, DO NOT ALTER BELOW WITHOUT CHANGING WRAPPERS
+  EXPORT LibSVM_Kernel:= ENUM(UNSIGNED2, LINEAR=0, POLY, RBF, SIGMOID, PRECOMPUTED);
+  EXPORT LibSVM_Type := ENUM(UNSIGNED2, C_SVC=0, NU_SVC, ONE_CLASS, EPSILON_SVR, NU_SVR);
+  EXPORT LibSVM_Node := RECORD  // Sparse 1 based and 0 based for pre-computed
+    INTEGER4 indx;  // -1 indicates end of vector when in LibSVM problem format
+    REAL8 value;
+  END;
+  EXPORT R8Entry := RECORD
+    REAL8 v;
+  END;
+  EXPORT I4Entry := RECORD
+    INTEGER4 v;
+  END;
+  EXPORT ECL_LibSVM_Problem := RECORD
+    UNSIGNED4 elements;
+    INTEGER4 entries;
+    UNSIGNED4 features;
+    REAL8 max_value;
+    DATASET(R8Entry, COUNT(SELF.entries)) y;
+    DATASET(LibSVM_Node, COUNT(SELF.elements)) x;
+  END;
+  EXPORT ECL_LibSVM_Parameter := RECORD
+    LibSVM_Type svmType;
+    LibSVM_Kernel kernelType;
+    INTEGER4 degree;    // for Poly
+    REAL8 gamma;        // for Poly, RBF, Sigmoid
+    REAL8 coef0;        // for Poly, Sigmoid
+  END;
+  EXPORT ECL_LibSVM_Train_Param:= RECORD(ECL_LibSVM_Parameter)
+    REAL8 cache_size;   // in MB
+    REAL8 eps;          // epsilon for stopping
+    REAL8 C;            // for C_SVC, EPSILON_SVR and nu_SVR
+    REAL8 nu;           // for NU_SVC, ONE_CLASS, and NU_SVR
+    REAL8 p;            // loss epsilon for EPISILON_SVR
+    INTEGER4 nr_weight; // number of weights for C_SVC
+    UNSIGNED2 shrinking;// shrinking heuristic if 1
+    UNSIGNED2 prob_est; // do probability estimates
+    DATASET(I4Entry, COUNT(SELF.nr_weight)) lbl;// weight labels for C_SVC
+    DATASET(R8Entry, COUNT(SELF.nr_weight)) weight;// for C_SVC
+  END;
+  EXPORT ECL_LibSVM_Model := RECORD
+    ECL_LibSVM_Parameter;
+    UNSIGNED4 k;  // number of classes
+    UNSIGNED4 l;  // number of support vectors
+    UNSIGNED4 elements; // number of nodes
+    UNSIGNED4 pairs_A; //k*(k-1)/2 or 0
+    UNSIGNED4 pairs_B; //k*(k-1)/2 or 0
+    UNSIGNED4 nr_label; //k or zero
+    UNSIGNED4 nr_nSV; // k or 0
+    DATASET(LibSVM_Node, COUNT(SELF.elements)) sv;
+    DATASET(R8Entry, COUNT((SELF.k-1)*SELF.l)) sv_coef;
+    DATASET(R8Entry, COUNT(SELF.k*(SELF.k-1)/2)) rho;
+    DATASET(R8Entry, COUNT(SELF.pairs_A)) probA;
+    DATASET(R8Entry, COUNT(SELF.pairs_B)) probB;
+    DATASET(I4Entry, COUNT(SELF.nr_label)) labels;
+    DATASET(I4Entry, COUNT(SELF.nr_nSV)) nSV;
+  END;
+  EXPORT CrossValidate_Result := RECORD
+    REAL8   mse;
+    REAL8   r_sq;
+    REAL8   correct;
+  END;
+  //Interface for C++ wrappers, DO NOT ALTER ABOVE WITHOUT CHANGING WRAPPERS
+  EXPORT SET OF UNSIGNED2 LibSVM_Version_set := [312,320];
+END;

--- a/ML/SVM/LibSVM/svm_cross_validate.ecl
+++ b/ML/SVM/LibSVM/svm_cross_validate.ecl
@@ -1,0 +1,145 @@
+//
+IMPORT ML.SVM.LibSVM.Types;
+IMPORT ML.SVM.LibSVM.Constants;
+IMPORT ML.SVM.LibSVM.Converted;
+// aliases
+Result := Types.CrossValidate_Result;
+Problem := Types.ECL_LibSVM_Problem;
+SVM_Parms := Types.ECL_LibSVM_Train_Param;
+ErrCode := Constants.LibSVM_BadParm;
+EXPORT Result svm_cross_validate(SVM_Parms prm,
+                                 Problem prb,
+                                 UNSIGNED2 nr_fold,
+                                 UNSIGNED4 err_code=ErrCode) := BEGINC++
+    extern "C" {
+      #include <libsvm/svm.h>
+    }
+    #if (LIBSVM_VERSION < 300 || LIBSVM_VERSION > 399)
+    #error Installed LibSVM version not known to be compatible
+    #endif
+    #ifndef ECL_LIBSVM_TRAIN_PARAM
+    #define ECL_LIBSVM_TRAIN_PARAM
+      typedef struct __attribute__ ((__packed__)) tagTrain {
+        unsigned short svm_type;
+        unsigned short kernel_type;
+        int degree;
+        double gamma;
+        double coef0;
+        double cache_size;
+        double eps;
+        double C;
+        double nu;
+        double p;
+        int nr_weight;
+        unsigned short shrinking;
+        unsigned short prob_est;   // array of int and array of double follows
+      } ecl_svm_parameter;
+    #endif
+    #ifndef ECL_SVM_PROBLEM
+    #define ECL_SVM_PROBLEM
+      typedef struct __attribute__ ((__packed__)) tagProblem {
+        unsigned int elements;
+        int entries;
+        unsigned int features;
+        double max_value;  // array of double and array of svm_node follow
+      } ecl_svm_problem;
+    #endif
+    #ifndef ECL_SVM_NODE
+    #define ECL_SVM_NODE
+      typedef struct __attribute__ ((__packed__))  tagPackedNode {
+        int indx;
+        double value;
+      } Packed_SVM_Node;
+    #endif
+    #ifndef ECL_CROSSVALIDATE_RESULT
+    #define ECL_CROSSVALIDATE_RESULT
+      typedef struct tagXVResult {
+        double mse;
+        double r_sq;
+        double correct;
+      } CrossValidate_Result;
+    #endif
+    #option library svm
+    #body
+    // convert ecl problem into svm problem structures
+    const ecl_svm_problem* ecl_problem = (ecl_svm_problem*) prb;
+    size_t len_base = sizeof(ecl_svm_problem);
+    const double * ecl_problem_y = (double*)(prb+len_base);
+    size_t len_y = ecl_problem->entries*sizeof(double);
+    const Packed_SVM_Node* in_nodes = (Packed_SVM_Node*)(prb+len_y+len_base);
+    size_t len_x_nodes = ecl_problem->elements*sizeof(svm_node);
+    struct svm_problem problem;
+    problem.l = ecl_problem->entries;
+    problem.y = (double*) rtlMalloc(len_y);
+    memcpy(problem.y, ecl_problem_y, len_y);
+    problem.x = (svm_node**) rtlMalloc(problem.l*sizeof(svm_node*));
+    svm_node* all_x = (svm_node*)rtlMalloc(len_x_nodes);
+    for (int i=0; i<ecl_problem->elements; i++) {
+      all_x[i].index = in_nodes[i].indx;
+      all_x[i].value = in_nodes[i].value;
+    }
+    int next_node = 0;
+    for (int k=0; k<problem.l; k++) {
+      problem.x[k] = &(all_x[next_node]);
+      while (next_node<ecl_problem->elements && all_x[next_node++].index != -1);
+    }
+    //
+    // Setup results
+    CrossValidate_Result *p = (CrossValidate_Result*) __result;
+    //
+    // Convert ecl parameter block to svm_parameter
+    const ecl_svm_parameter* ecl_parms = (ecl_svm_parameter*) prm;
+    struct svm_parameter parameter;
+    parameter.svm_type = ecl_parms->svm_type;
+    parameter.kernel_type = ecl_parms->kernel_type;
+    parameter.degree = ecl_parms->degree;
+    parameter.gamma = (ecl_parms->gamma==0.0 && ecl_problem->features>0)
+                    ? 1.0/ecl_problem->features
+                    : ecl_parms->gamma;
+    parameter.coef0 = ecl_parms->coef0;
+    parameter.cache_size = ecl_parms->cache_size;
+    parameter.eps = ecl_parms->eps;
+    parameter.C = ecl_parms->C;
+    parameter.nr_weight = ecl_parms->nr_weight;
+    parameter.nu = ecl_parms->nu;
+    parameter.p = ecl_parms->p;
+    parameter.shrinking = ecl_parms->shrinking;
+    parameter.probability = ecl_parms->prob_est;
+    size_t len_weight_labels = ecl_parms->nr_weight*sizeof(int);
+    parameter.weight_label = (int*) rtlMalloc(len_weight_labels);
+    const void* prm_weight_labels = prm+sizeof(ecl_svm_problem);
+    memcpy(parameter.weight_label, prm_weight_labels,len_weight_labels);
+    size_t len_weights = ecl_parms->nr_weight * sizeof(double);
+    parameter.weight = (double*) rtlMalloc(len_weights);
+    const void* prm_weights = prm_weight_labels + len_weight_labels;
+    memcpy(parameter.weight, prm_weights, len_weights);
+    // check parameters
+    const char * err_msg = svm_check_parameter(&problem, &parameter);
+    if (err_msg) rtlFail(err_code, err_msg);
+    // call LibSVM cross validate and summarize results
+    int total_correct = 0;
+    double tot_sq_err = 0.0;
+    double* target = (double*) rtlMalloc(ecl_problem->entries*sizeof(double));
+    double sumv = 0.0, sumy = 0.0, sumvv = 0.0, sumyy = 0.0, sumvy = 0.0;
+    svm_cross_validation(&problem,&parameter,nr_fold,target);
+    for (int i=0; i<problem.l; i++) {
+      if (target[i]==ecl_problem_y[i]) total_correct++;
+      tot_sq_err += (target[i]-ecl_problem_y[i])*(target[i]-ecl_problem_y[i]);
+      sumv += target[i];
+      sumy += ecl_problem_y[i];
+      sumvv += target[i]*target[i];
+      sumyy += ecl_problem_y[i]*ecl_problem_y[i];
+      sumvy += target[i]*ecl_problem_y[i];
+    }
+    p->correct = 100.0 * total_correct / problem.l;
+    p->mse = tot_sq_err / problem.l;
+    p->r_sq = ((problem.l*sumvy-sumv*sumy)*(problem.l*sumvy-sumv*sumy))
+            / ((problem.l*sumvv-sumv*sumv)*(problem.l*sumyy-sumy*sumy));
+    //
+    //free work areas and return
+    svm_destroy_param(&parameter);  // frees weight data
+    free(target);
+    free(problem.y);
+    free(problem.x);
+    free(all_x);
+  ENDC++;

--- a/ML/SVM/LibSVM/svm_predict.ecl
+++ b/ML/SVM/LibSVM/svm_predict.ecl
@@ -1,0 +1,133 @@
+// Predict Y for a vector
+// Create a model from training data
+IMPORT ML.SVM.LibSVM.Types;
+IMPORT ML.SVM.LibSVM.Constants;
+IMPORT ML.SVM.LibSVM.Converted;
+// aliases
+Model := Types.ECL_LibSVM_Model;
+Node  := Types.LibSVM_Node;
+ErrCode := Constants.LibSVM_BadParm;
+EXPORT REAL8 svm_predict(Model ecl_model, DATASET(Node) ecl_nodes) := BEGINC++
+  extern "C" {
+    #include <libsvm/svm.h>
+  }
+  #if (LIBSVM_VERSION < 300 || LIBSVM_VERSION > 399)
+  #error Installed LibSVM version not known to be compatible
+  #endif
+    #ifndef ECL_SVM_NODE
+    #define ECL_SVM_NODE
+    typedef struct __attribute__ ((__packed__))  tagPackedNode {
+      int indx;
+      double value;
+    } Packed_SVM_Node;
+  #endif
+  #ifndef ECL_SVM_MODEL
+  #define ECL_SVM_MODEL
+    typedef struct __attribute__ ((__packed__)) tagModel {
+      unsigned short svm_type;
+      unsigned short kernel_type;
+      int degree;
+      double gamma;
+      double coef0;
+      unsigned int k;   // number classes
+      unsigned int l;   // number of support vectors
+      unsigned int elements; // number of elements
+      unsigned int pairs_A; // prob A pairs or zero
+      unsigned int pairs_B; // prob B pairs or zero
+      unsigned int nr_label; // number of labels, 0
+      unsigned int nr_nSV; // number of support vector inx, 0
+    } Packed_SVM_Model; // Packed arrays follow.
+  #endif
+  #option library svm
+  #body
+  //Convert into LibSVM formats, first the x vector
+  const Packed_SVM_Node* in_node = (Packed_SVM_Node*) ecl_nodes;
+  int obs = lenEcl_nodes/sizeof(Packed_SVM_Node); // includes -1 entry
+  struct svm_node* x = (struct svm_node*) malloc(obs*sizeof(struct svm_node));
+  for (int i=0; i<obs; i++) {
+    x[i].index = in_node[i].indx;
+    x[i].value = in_node[i].value;
+  }
+  // now the model
+  const Packed_SVM_Model* in_mdl = (Packed_SVM_Model*) ecl_model;
+  struct svm_model* mdl = (struct svm_model*) malloc(sizeof(struct svm_model));
+  mdl->free_sv = 0;
+  mdl->param.svm_type = in_mdl->svm_type;
+  mdl->param.kernel_type = in_mdl->kernel_type;
+  mdl->param.degree = in_mdl->degree;
+  mdl->param.gamma = in_mdl->gamma;
+  mdl->param.coef0 = in_mdl->coef0;
+  mdl->nr_class = in_mdl->k;
+  mdl->l = in_mdl->l;
+  // SV
+  int elements = in_mdl->elements;
+  struct svm_node* x_all = (struct svm_node*) NULL;
+  const Packed_SVM_Node* sv_in = (Packed_SVM_Node*) (in_mdl+1);
+  mdl->SV = (struct svm_node **) malloc(in_mdl->l*sizeof(struct svm_node *));
+  int curr_sv = 0;
+  size_t len_x_nodes = elements*sizeof(struct svm_node);
+  x_all = (struct svm_node*) malloc(len_x_nodes);
+  mdl->SV[0] = x_all;
+  x_all[0].index = sv_in[0].indx;
+  x_all[0].value = sv_in[0].value;
+  for (int i=1; i<elements; i++) {
+    if (sv_in[i-1].indx == -1) mdl->SV[++curr_sv] = x_all+i;
+    x_all[i].index = sv_in[i].indx;
+    x_all[i].value = sv_in[i].value;
+  }
+  // coef
+  const double* sv_coef = (double*) (sv_in + elements);
+  size_t num_coef = (in_mdl->k-1) * in_mdl->l;
+  mdl->sv_coef = (double**) malloc((in_mdl->k-1)*sizeof(double*));
+  for (int i=0; i<in_mdl->k-1; i++) {
+    mdl->sv_coef[i] = (double*) malloc(in_mdl->l*sizeof(double));
+    for (int j=0; j<in_mdl->l; j++) {
+      mdl->sv_coef[i][j] = sv_coef[((in_mdl->k-1)*i)+j];
+    }
+  }
+  // rho
+  const double* rho = sv_coef + num_coef;
+  size_t num_pairs = in_mdl->k * (in_mdl->k-1)/2;//rho
+  mdl->rho = (double*) malloc(num_pairs*sizeof(double));
+  memcpy(mdl->rho, rho, num_pairs*sizeof(double));
+  // ProbA
+  const double* probA = rho + num_pairs;
+  if (in_mdl->pairs_A > 0) {
+    mdl->probA = (double*) malloc(in_mdl->pairs_A*sizeof(double));
+    memcpy(mdl->probA, probA, in_mdl->pairs_A*sizeof(double));
+  } else mdl->probA = (double*) NULL;
+  // ProbB
+  const double* probB = probA + in_mdl->pairs_A;
+  if (in_mdl->pairs_B > 0) {
+    mdl->probB = (double*) malloc(in_mdl->pairs_B*sizeof(double));
+    memcpy(mdl->probB, probB, in_mdl->pairs_B*sizeof(double));
+  } else mdl->probB = (double*) NULL;
+  // label
+  const int * label = (int*) (probB + in_mdl->pairs_B);
+  if (in_mdl->nr_label>0) {
+    mdl->label = (int*) malloc(in_mdl->nr_label*sizeof(int));
+    memcpy(mdl->label, label, in_mdl->nr_label*sizeof(int));
+  } else mdl->label = (int*) NULL;
+  // nSV
+  const int * nSV = label + in_mdl->nr_label;
+  if (in_mdl->nr_nSV > 0) {
+    mdl->nSV = (int*) malloc(in_mdl->nr_nSV*sizeof(int));
+    memcpy(mdl->nSV, nSV, in_mdl->nr_nSV*sizeof(int));
+  } else mdl->nSV = (int*) NULL;
+  // get prediction
+  double rslt = svm_predict(mdl, x);
+  // Free work areas
+  if (mdl->label) free(mdl->label);
+  //if (mdl->sv_indices) free(mdl->sv_indices);
+  if (mdl->probB) free(mdl->probB);
+  if (mdl->probA) free(mdl->probA);
+  free(mdl->rho);
+  for (int i=0; i<mdl->nr_class-1; i++) free(mdl->sv_coef[i]);
+  free(mdl->sv_coef);
+  free(mdl->SV);
+  free(x_all);
+  free(mdl);
+  free(x);
+  // all done
+  return rslt;
+ENDC++;

--- a/ML/SVM/LibSVM/svm_train.ecl
+++ b/ML/SVM/LibSVM/svm_train.ecl
@@ -1,0 +1,213 @@
+// Create a model from training data
+IMPORT ML.SVM.LibSVM.Types;
+IMPORT ML.SVM.LibSVM.Constants;
+IMPORT ML.SVM.LibSVM.Converted;
+// aliases
+ECL_LibSVM_Model := Types.ECL_LibSVM_Model;
+Problem := Types.ECL_LibSVM_Problem;
+SVM_Parms := Types.ECL_LibSVM_Train_Param;
+ErrCode := Constants.LibSVM_BadParm;
+DATA svm_train_d(SVM_Parms prm,
+                 Problem prb,
+                 UNSIGNED4 err_code=ErrCode) := BEGINC++
+  extern "C" {
+    #include <libsvm/svm.h>
+  }
+  #if (LIBSVM_VERSION < 300 || LIBSVM_VERSION > 399)
+  #error Installed LibSVM version not known to be compatible
+  #endif
+  #ifndef ECL_LIBSVM_TRAIN_PARAM
+  #define ECL_LIBSVM_TRAIN_PARAM
+    typedef struct __attribute__ ((__packed__)) tagTrain {
+      unsigned short svm_type;
+      unsigned short kernel_type;
+      int degree;
+      double gamma;
+      double coef0;
+      double cache_size;
+      double eps;
+      double C;
+      double nu;
+      double p;
+      int nr_weight;
+      unsigned short shrinking;
+      unsigned short prob_est;   // array of int and array of double follows
+    } ecl_svm_parameter;
+  #endif
+  #ifndef ECL_SVM_PROBLEM
+  #define ECL_SVM_PROBLEM
+    typedef struct __attribute__ ((__packed__)) tagProblem {
+      unsigned int elements;
+      int entries;
+      unsigned int features;
+      double max_value;  // array of double and array of svm_node follow
+    } ecl_svm_problem;
+    #endif
+    #ifndef ECL_SVM_NODE
+    #define ECL_SVM_NODE
+    typedef struct __attribute__ ((__packed__))  tagPackedNode {
+      int indx;
+      double value;
+    } Packed_SVM_Node;
+  #endif
+  #ifndef ECL_SVM_MODEL
+  #define ECL_SVM_MODEL
+    typedef struct __attribute__ ((__packed__)) tagModel {
+      unsigned short svm_type;
+      unsigned short kernel_type;
+      int degree;
+      double gamma;
+      double coef0;
+      unsigned int k;   // number classes
+      unsigned int l;   // number of support vectors
+      unsigned int elements; // number of elements
+      unsigned int pairs_A; // prob A pairs or zero
+      unsigned int pairs_B; // prob B pairs or zero
+      unsigned int nr_label; // number of labels, 0
+      unsigned int nr_nSV; // number of support vector inx, 0
+    } Packed_SVM_Model; // Packed arrays follow.
+  #endif
+  #option library svm
+  #body
+  // convert ecl problem into svm problem structures
+  const ecl_svm_problem* ecl_problem = (ecl_svm_problem*) prb;
+  size_t len_base = sizeof(ecl_svm_problem);
+  const double * ecl_problem_y = (double*)(prb+len_base);
+  size_t len_y = ecl_problem->entries*sizeof(double);
+  const Packed_SVM_Node* in_nodes = (Packed_SVM_Node*)(prb+len_y+len_base);
+  size_t len_x_nodes = ecl_problem->elements*sizeof(svm_node);
+  struct svm_problem problem;
+  problem.l = ecl_problem->entries;
+  problem.y = (double*) rtlMalloc(len_y);
+  memcpy(problem.y, ecl_problem_y, len_y);
+  problem.x = (svm_node**) rtlMalloc(problem.l*sizeof(svm_node*));
+  svm_node* all_x = (svm_node*)rtlMalloc(len_x_nodes);
+  for (int i=0; i<ecl_problem->elements; i++) {
+    all_x[i].index = in_nodes[i].indx;
+    all_x[i].value = in_nodes[i].value;
+  }
+  int next_node = 0;
+  for (int k=0; k<problem.l; k++) {
+    problem.x[k] = &(all_x[next_node]);
+    while (next_node<ecl_problem->elements && all_x[next_node++].index != -1);
+  }
+  //
+  // Convert ecl parameter block to svm_parameter
+  const ecl_svm_parameter* ecl_parms = (ecl_svm_parameter*) prm;
+  struct svm_parameter parameter;
+  parameter.svm_type = ecl_parms->svm_type;
+  parameter.kernel_type = ecl_parms->kernel_type;
+  parameter.degree = ecl_parms->degree;
+  parameter.gamma = (ecl_parms->gamma==0.0 && ecl_problem->features>0)
+                  ? 1.0/ecl_problem->features
+                  : ecl_parms->gamma;
+  parameter.coef0 = ecl_parms->coef0;
+  parameter.cache_size = ecl_parms->cache_size;
+  parameter.eps = ecl_parms->eps;
+  parameter.C = ecl_parms->C;
+  parameter.nr_weight = ecl_parms->nr_weight;
+  parameter.nu = ecl_parms->nu;
+  parameter.p = ecl_parms->p;
+  parameter.shrinking = ecl_parms->shrinking;
+  parameter.probability = ecl_parms->prob_est;
+  size_t len_weight_labels = ecl_parms->nr_weight*sizeof(int);
+  parameter.weight_label = (int*) rtlMalloc(len_weight_labels);
+  const void* prm_weight_labels = prm+sizeof(ecl_svm_problem);
+  memcpy(parameter.weight_label, prm_weight_labels,len_weight_labels);
+  size_t len_weights = ecl_parms->nr_weight * sizeof(double);
+  parameter.weight = (double*) rtlMalloc(len_weights);
+  const void* prm_weights = prm_weight_labels + len_weight_labels;
+  memcpy(parameter.weight, prm_weights, len_weights);
+  //
+  // check parameters
+  const char * err_msg = svm_check_parameter(&problem, &parameter);
+  if (err_msg) rtlFail(err_code, err_msg);
+  //
+  // determine model
+  struct svm_model* model;
+  model = svm_train(&problem, &parameter);
+  //
+  // Setup results
+  size_t elements = 0;
+  if (model->param.kernel_type == PRECOMPUTED) elements = 2*model->l;
+  else for (int i=0; i<model->l; i++) {
+    svm_node* p = model->SV[i];
+    int j = 0;
+    elements++; // account for the -1 entry
+    while (p[j++].index != -1) elements++;
+  }
+  size_t num_coef = (model->nr_class-1) * model->l;
+  size_t num_pairs = model->nr_class * (model->nr_class-1)/2;//rho
+  size_t num_probA = (model->probA) ? num_pairs  : 0;
+  size_t num_probB = (model->probB) ? num_pairs  : 0;
+  size_t num_doubles = num_coef + num_pairs + num_probA + num_probB;
+  size_t num_nSV = (model->nSV) ? model->nr_class  : 0;
+  size_t num_label = (model->label) ? model->nr_class : 0;
+  size_t num_ints = num_nSV + num_label;
+  size_t sz = num_doubles*sizeof(double) + elements*sizeof(Packed_SVM_Node)
+            + num_ints*sizeof(int) + sizeof(Packed_SVM_Model);
+  __lenResult = sz;
+  __result = rtlMalloc(sz);
+  Packed_SVM_Model* outModel = (Packed_SVM_Model*) __result;
+  outModel->svm_type = model->param.svm_type;
+  outModel->kernel_type = model->param.kernel_type;
+  outModel->degree = model->param.degree;
+  outModel->gamma = model->param.gamma;
+  outModel->coef0 = model->param.coef0;
+  outModel->k = model->nr_class;
+  outModel->l = model->l;
+  outModel->elements = elements;
+  outModel->pairs_A = num_probA;
+  outModel->pairs_B = num_probB;
+  outModel->nr_label = num_label;
+  outModel->nr_nSV = num_nSV;
+  Packed_SVM_Node* sv_array = (Packed_SVM_Node*) (outModel+1);
+  int sv_pos = 0;
+  for (int i=0; i<model->l; i++) {
+    if (model->param.kernel_type == PRECOMPUTED) {
+      sv_array[sv_pos].indx  = 0;
+      sv_array[sv_pos].value = (int) model->SV[i][0].value;
+      sv_pos++;
+    } else {
+      for (int j=0; model->SV[i][j].index>0; j++) {
+        sv_array[sv_pos].indx  = model->SV[i][j].index;
+        sv_array[sv_pos].value = model->SV[i][j].value;
+        sv_pos++;
+      }
+    }
+    sv_array[sv_pos].indx = -1;
+    sv_array[sv_pos].value = 0.0;
+    sv_pos++;
+  }
+  double* sv_coef = (double*) (sv_array + elements);
+  for (int i=0; i<model->nr_class-1; i++) {
+    for (int j=0; j<model->l; j++) {
+      sv_coef[((model->nr_class-1)*i)+j] = model->sv_coef[i][j];
+    }
+   }
+  //
+  double* rho = sv_coef + num_coef;
+  memcpy(rho, model->rho, num_pairs*sizeof(double));
+  //
+  double* probA = rho + num_pairs;
+  memcpy(probA, model->probA, num_probA * sizeof(double));
+  //
+  double* probB = probA + num_probA;
+  memcpy(probB, model->probB, num_probB * sizeof(double));
+  //
+  int * label = (int*) (probB + num_probB);
+  memcpy(label, model->label, num_label * sizeof(int));
+  //
+  int* nSV = label + num_label;
+  memcpy(nSV, model->nSV, num_nSV * sizeof(int));
+  //
+  //free work areas and return
+  svm_free_and_destroy_model(&model);
+  svm_destroy_param(&parameter);  // frees weight data
+  free(problem.y);
+  free(problem.x);
+  free(all_x);
+ENDC++;
+
+EXPORT ECL_LibSVM_Model svm_train(SVM_Parms prm, Problem prb)
+            := TRANSFER(svm_train_d(prm, prb), ECL_LibSVM_Model);

--- a/ML/SVM/Types.ecl
+++ b/ML/SVM/Types.ecl
@@ -107,7 +107,7 @@ EXPORT Types := MODULE
   EXPORT SVM_Pred_Values := RECORD(SVM_Prediction)
     DATASET(R8Entry) decision_values;
   END;
-  EXPORT SVM_Pred_Probability := RECORD(SVM_Prediction)
+  EXPORT SVM_Pred_Prob_Est := RECORD(SVM_Prediction)
     DATASET(R8Entry) prob_estimates;
   END;
 END;

--- a/ML/SVM/Types.ecl
+++ b/ML/SVM/Types.ecl
@@ -104,4 +104,10 @@ EXPORT Types := MODULE
     REAL8 target_y;   // from input
     REAL8 predict_y;  // from SVM
   END;
+  EXPORT SVM_Pred_Values := RECORD(SVM_Prediction)
+    DATASET(R8Entry) decision_values;
+  END;
+  EXPORT SVM_Pred_Probability := RECORD(SVM_Prediction)
+    DATASET(R8Entry) prob_estimates;
+  END;
 END;

--- a/ML/SVM/Types.ecl
+++ b/ML/SVM/Types.ecl
@@ -1,0 +1,107 @@
+// Types Support Vector Machine
+IMPORT ML.SVM.LibSVM.Types AS LibSVM_Types;
+EXPORT Types := MODULE
+  EXPORT Model_ID := UNSIGNED4;
+  EXPORT R8Entry := LibSVM_Types.R8Entry;
+  EXPORT I4Entry := LibSVM_Types.I4Entry;
+  EXPORT SVM_Type := LibSVM_Types.LibSVM_Type;
+  EXPORT Kernel_Type := LibSVM_Types.LibSVM_Kernel;
+  EXPORT SVM_Feature := RECORD
+    UNSIGNED4 nominal;
+    REAL8 v;
+  END;
+  EXPORT SVM_Instance := RECORD
+    UNSIGNED8 rid;    // source identifier
+    REAL8 y;          // label
+    REAL8 max_value;  // max value of the feature
+    DATASET(SVM_Feature) x;
+  END;
+  EXPORT SVM_SV := RECORD
+    UNSIGNED v_ord;
+    DATASET(SVM_Feature) features;
+  END;
+  EXPORT SVM_Grid_Args := RECORD
+    REAL8 start;
+    REAL8 stop;
+    REAL8 max_incr;
+  END;
+  EXPORT SVM_Grid_Plan := RECORD
+    UNSIGNED4 folds;
+    SVM_Grid_Args log2_C;
+    SVM_Grid_Args log2_gamma;
+  END;
+  EXPORT Training_Base := RECORD
+    SVM_Type svmType;
+    Kernel_Type kernelType;
+    INTEGER4 degree;    // for Poly
+    REAL8 coef0;        // for Poly, Sigmoid
+    REAL8 eps;          // epsilon for stopping
+    REAL8 nu;           // for NU_SVC, ONE_CLASS, and NU_SVR
+    REAL8 p;            // loss epsilon for EPISILON_SVR
+    INTEGER4 nr_weight; // number of weights for C_SVC
+    BOOLEAN shrinking;  // shrinking heuristic if TRUE
+    BOOLEAN prob_est;   // do probability estimates
+    DATASET(I4Entry) lbl;// weight labels for C_SVC
+    DATASET(R8Entry) weight;// for C_SVC
+  END;
+  EXPORT Training_Parameters := RECORD
+    Model_ID id;
+    Training_Base;
+    REAL8 gamma;        // for Poly, RBF, Sigmoid
+    REAL8 C;            // for C_SVC, EPSILON_SVR and nu_SVR
+  END;
+  EXPORT Model := RECORD
+    Model_ID id;
+    SVM_Type svmType;
+    Kernel_Type kernelType;
+    INTEGER4 degree;    // for Poly
+    REAL8 gamma;        // for Poly, RBF, Sigmoid
+    REAL8 coef0;        // for Poly, Sigmoid
+    UNSIGNED4 k;  // number of classes
+    UNSIGNED4 l;  // number of support vectors
+    DATASET(SVM_SV) sv;
+    DATASET(R8Entry) sv_coef;
+    DATASET(R8Entry) rho;
+    DATASET(R8Entry) probA;
+    DATASET(R8Entry) probB;
+    DATASET(I4Entry) labels;
+    DATASET(I4Entry) nSV;
+  END;
+  EXPORT CrossValidate_Result := RECORD
+    Model_ID id;
+    REAL8   correct;
+    REAL8   mse;
+    REAL8   r_sq;
+  END;
+  EXPORT GridSearch_Result := RECORD(CrossValidate_Result)
+    REAL8 C;
+    REAL8 gamma;
+    Training_Base;
+  END;
+  EXPORT Feature_Scale := RECORD
+    UNSIGNED4 nominal;
+    REAL8 min_value;
+    REAL8 max_value;
+  END;
+  EXPORT Class_Scale := RECORD
+    REAL8 y_min;
+    REAL8 y_max;
+  END;
+  EXPORT Scale_Parms := RECORD
+    REAL8 x_lower;
+    REAL8 x_upper;
+    REAL8 y_lower;
+    REAL8 y_upper;
+  END;
+  EXPORT SVM_Scale := RECORD
+    Scale_Parms;
+    Class_Scale;
+    DATASET(Feature_Scale) features;
+  END;
+  EXPORT SVM_Prediction := RECORD
+    Model_ID id;
+    UNSIGNED8 rid;    // source identifier
+    REAL8 target_y;   // from input
+    REAL8 predict_y;  // from SVM
+  END;
+END;

--- a/ML/SVM/cross_validate.ecl
+++ b/ML/SVM/cross_validate.ecl
@@ -1,0 +1,33 @@
+IMPORT ML.SVM.Types;
+IMPORT ML.SVM.LibSVM.Types AS LibSVM_Types;
+IMPORT ML.SVM.LibSVM;
+IMPORT ML.SVM.LibSVM.Converted;
+// aliases for convenience
+Parms := Types.Training_Parameters;
+Instance := Types.SVM_Instance;
+XV_Result := Types.CrossValidate_Result;
+Problem := LibSVM_Types.ECL_LibSVM_Problem;
+SVM_Parms := LibSVM_Types.ECL_LibSVM_Train_Param;
+
+EXPORT cross_validate(DATASET(Parms) p,
+                      DATASET(Instance) d,
+                      UNSIGNED2 folds):= FUNCTION
+  Work1 := RECORD(SVM_Parms)
+    Types.Model_ID id;
+  END;
+  Work1 cvt2Parm(Parms p) := TRANSFORM
+    SELF.cache_size := 100;
+    SELF.prob_est := IF(p.prob_est, 1, 0);
+    SELF.shrinking := IF(p.shrinking, 1, 0);
+    SELF := p;
+  END;
+  parm_data := PROJECT(p, cvt2Parm(LEFT));
+  problem_data := Converted.Instance2Problem(d); // 1 record file
+  XV_Result LibSVM_Call(Work1 prm, Problem d) := TRANSFORM
+    SELF.id := prm.id;
+    SELF := LibSVM.svm_cross_validate(prm, d, folds);
+  END;
+  rslt := JOIN(parm_data, problem_data, TRUE,
+               LibSVM_Call(LEFT, RIGHT), ALL);
+  RETURN rslt;
+END;

--- a/ML/SVM/grid_search.ecl
+++ b/ML/SVM/grid_search.ecl
@@ -1,0 +1,35 @@
+//Generate a set of models in a grid search to establish C and gamma
+IMPORT ML.SVM;
+IMPORT ML.SVM.Types;
+IMPORT std.system.Thorlib;
+//Aliases
+G_Result := Types.GridSearch_Result;
+Grid_Plan := Types.SVM_Grid_Plan;
+Grid_Args := Types.SVM_Grid_Args;
+T_Base := Types.Training_Base;
+T_Parm := Types.Training_Parameters;
+Inst := Types.SVM_Instance;
+EXPORT grid_search(Grid_Plan plan, T_Base base, DATASET(Inst) d) := FUNCTION
+  MyNodes := Thorlib.nodes();
+  //only 1 step, use all the nodes, or use all nodes several times
+  // FLOOR(((range_of_interest/max_incr)+nodes-1) DIV nodes) * nodes
+  StepsNeeded(Grid_Args arg) :=
+      MAP(arg.start=arg.stop      => 1,
+          arg.max_incr=0.0        => (arg.stop-arg.start) DIV MyNodes,
+          ((((arg.stop-arg.start)/arg.max_incr)+MyNodes-1) DIV MyNodes)*MyNodes);
+  IncrNeeded(Grid_Args arg, UNSIGNED steps) := (arg.stop-arg.start) / steps;
+  C_steps := StepsNeeded(plan.log2_C);
+  C_Incr := IncrNeeded(plan.log2_C, C_steps);
+  gamma_steps := StepsNeeded(plan.log2_gamma);
+  gamma_incr := IncrNeeded(plan.log2_gamma, gamma_steps);
+  search_steps := C_steps * gamma_steps;
+  T_Parm makeParm(Grid_Plan plan, T_Base base, UNSIGNED c) := TRANSFORM
+    SELF.id := c;
+    SELF.C := POWER(2,plan.log2_C.start + (((c-1) DIV gamma_steps)*C_incr));
+    SELF.gamma := POWER(2,plan.log2_gamma.start+(((c-1)%gamma_steps)*gamma_incr));
+    SELF := base;
+  END;
+  parms := DATASET(search_steps, makeParm(plan, base, COUNTER), DISTRIBUTED);
+  rslt := SVM.cross_validate(parms, d, plan.folds);
+  RETURN rslt;
+END;

--- a/ML/SVM/predict.ecl
+++ b/ML/SVM/predict.ecl
@@ -7,27 +7,29 @@ SVM_Model := LibSVM.Types.ECL_LibSVM_Model;
 SVM_Output:= LibSVM.Types.LibSVM_Output;
 SVM_Instance := SVM.Types.SVM_Instance;
 SVM_Prediction := SVM.Types.SVM_Prediction;
+SVM_Pred_Values := SVM.Types.SVM_Pred_Values;
+SVM_Pred_Prob_Est := SVM.Types.SVM_Pred_Prob_Est;
 SVM_Predict := LibSVM.SVM_Predict;
 LibSVM_Node := LibSVM.Types.LibSVM_Node;
 //
-EXPORT predict(DATASET(Model) models, DATASET(SVM_Instance) d) := FUNCTION
-  LibSVM.Types.LibSVM_Node cvtNode(SVM.Types.SVM_Feature f) := TRANSFORM
+EXPORT Predict(DATASET(Model) models, DATASET(SVM_Instance) d) := MODULE
+  SHARED LibSVM.Types.LibSVM_Node cvtNode(SVM.Types.SVM_Feature f) := TRANSFORM
     SELF.indx := f.nominal;
     SELF.value := f.v;
   END;
-  Work_SV := RECORD
+  SHARED Work_SV := RECORD
     UNSIGNED4 v_ord;
     DATASET(LibSVM_Node) nodes;
   END;
-  Work_SV cvtSV(SVM.Types.SVM_SV sv_rec) := TRANSFORM
+  SHARED Work_SV cvtSV(SVM.Types.SVM_SV sv_rec) := TRANSFORM
     SELF.v_ord := sv_rec.v_ord;
     SELF.nodes := PROJECT(sv_rec.features, cvtNode(LEFT))
                 & DATASET([{-1, 0.0}], LibSVM_Node);
   END;
-  Work1 := RECORD(SVM_Model)
+  SHARED Work1 := RECORD(SVM_Model)
     SVM.Types.Model_ID id;
   END;
-  LibSVM_Node normN(LibSVM_Node node) := TRANSFORM
+  SHARED LibSVM_Node normN(LibSVM_Node node) := TRANSFORM
     SELF := node;
   END;
   Work1 cvtModel(Model m) := TRANSFORM
@@ -40,8 +42,9 @@ EXPORT predict(DATASET(Model) models, DATASET(SVM_Instance) d) := FUNCTION
     SELF.nr_label := COUNT(m.labels);
     SELF := m;
   END;
-  svm_mdls := PROJECT(models, cvtModel(LEFT));
-  SVM_Prediction predict(SVM_Instance inst, Work1 m) := TRANSFORM
+  SHARED svm_mdls := PROJECT(models, cvtModel(LEFT));
+  // Prediction only
+  SVM_Prediction p_only(SVM_Instance inst, Work1 m) := TRANSFORM
     x_nodes := PROJECT(inst.x,cvtNode(LEFT))
              & DATASET([{-1,0.0}], LibSVM_Node);
     SELF.id := m.id;
@@ -49,6 +52,29 @@ EXPORT predict(DATASET(Model) models, DATASET(SVM_Instance) d) := FUNCTION
     SELF.target_y := inst.y;
     SELF.predict_y := SVM_Predict(m, x_nodes, SVM_Output.LABEL_ONLY)[1].v;
   END;
-  rslt := JOIN(d, svm_mdls, TRUE, predict(LEFT, RIGHT), ALL);
-  RETURN rslt;
+  EXPORT Prediction := JOIN(d, svm_mdls, TRUE, p_only(LEFT, RIGHT), ALL);
+  // Prediction and decision values.  Values are empty if not supported
+  SVM_Pred_Values p_values(SVM_Instance inst, Work1 m) := TRANSFORM
+    x_nodes := PROJECT(inst.x,cvtNode(LEFT))
+             & DATASET([{-1,0.0}], LibSVM_Node);
+    rslt_array := SVM_Predict(m, x_nodes, SVM_Output.VALUES);
+    SELF.id := m.id;
+    SELF.rid := inst.rid;
+    SELF.target_y := inst.y;
+    SELF.predict_y := rslt_array[1].v;
+    SELF.decision_values := CHOOSEN(rslt_array, ALL, 2);
+  END;
+  EXPORT Pred_Values := JOIN(d, svm_mdls, TRUE, p_values(LEFT, RIGHT), ALL);
+  // Prediction and probabilities.  Probability estimates empty if not supported.
+  SVM_Pred_Prob_Est p_pest(SVM_Instance inst, Work1 m) := TRANSFORM
+    x_nodes := PROJECT(inst.x,cvtNode(LEFT))
+             & DATASET([{-1,0.0}], LibSVM_Node);
+    rslt_array := SVM_Predict(m, x_nodes, SVM_Output.PROBS);
+    SELF.id := m.id;
+    SELF.rid := inst.rid;
+    SELF.target_y := inst.y;
+    SELF.predict_y := rslt_array[1].v;
+    SELF.prob_estimates := CHOOSEN(rslt_array, ALL, 2);
+  END;
+  EXPORT Pred_Prob_Est := JOIN(d, svm_mdls, TRUE, p_pest(LEFT, RIGHT), ALL);
 END;

--- a/ML/SVM/predict.ecl
+++ b/ML/SVM/predict.ecl
@@ -1,0 +1,53 @@
+// Produce a data set of predictions for each model
+IMPORT ML.SVM;
+IMPORT ML.SVM.LibSVM;
+// aliases
+Model := SVM.Types.Model;
+SVM_Model := LibSVM.Types.ECL_LibSVM_Model;
+SVM_Instance := SVM.Types.SVM_Instance;
+SVM_Prediction := SVM.Types.SVM_Prediction;
+SVM_Predict := LibSVM.SVM_Predict;
+LibSVM_Node := LibSVM.Types.LibSVM_Node;
+//
+EXPORT predict(DATASET(Model) models, DATASET(SVM_Instance) d) := FUNCTION
+  LibSVM.Types.LibSVM_Node cvtNode(SVM.Types.SVM_Feature f) := TRANSFORM
+    SELF.indx := f.nominal;
+    SELF.value := f.v;
+  END;
+  Work_SV := RECORD
+    UNSIGNED4 v_ord;
+    DATASET(LibSVM_Node) nodes;
+  END;
+  Work_SV cvtSV(SVM.Types.SVM_SV sv_rec) := TRANSFORM
+    SELF.v_ord := sv_rec.v_ord;
+    SELF.nodes := PROJECT(sv_rec.features, cvtNode(LEFT))
+                & DATASET([{-1, 0.0}], LibSVM_Node);
+  END;
+  Work1 := RECORD(SVM_Model)
+    SVM.Types.Model_ID id;
+  END;
+  LibSVM_Node normN(LibSVM_Node node) := TRANSFORM
+    SELF := node;
+  END;
+  Work1 cvtModel(Model m) := TRANSFORM
+    sv := NORMALIZE(PROJECT(m.sv, cvtSV(LEFT)), LEFT.nodes, normN(RIGHT));
+    SELF.sv := sv;
+    SELF.elements := COUNT(sv);
+    SELF.nr_nSV := COUNT(m.nSV);
+    SELF.pairs_A := COUNT(m.probA);
+    SELF.pairs_B := COUNT(m.probB);
+    SELF.nr_label := COUNT(m.labels);
+    SELF := m;
+  END;
+  svm_mdls := PROJECT(models, cvtModel(LEFT));
+  SVM_Prediction predict(SVM_Instance inst, Work1 m) := TRANSFORM
+    x_nodes := PROJECT(inst.x,cvtNode(LEFT))
+             & DATASET([{-1,0.0}], LibSVM_Node);
+    SELF.id := m.id;
+    SELF.rid := inst.rid;
+    SELF.target_y := inst.y;
+    SELF.predict_y := SVM_Predict(m, x_nodes);
+  END;
+  rslt := JOIN(d, svm_mdls, TRUE, predict(LEFT, RIGHT), ALL);
+  RETURN rslt;
+END;

--- a/ML/SVM/predict.ecl
+++ b/ML/SVM/predict.ecl
@@ -4,6 +4,7 @@ IMPORT ML.SVM.LibSVM;
 // aliases
 Model := SVM.Types.Model;
 SVM_Model := LibSVM.Types.ECL_LibSVM_Model;
+SVM_Output:= LibSVM.Types.LibSVM_Output;
 SVM_Instance := SVM.Types.SVM_Instance;
 SVM_Prediction := SVM.Types.SVM_Prediction;
 SVM_Predict := LibSVM.SVM_Predict;
@@ -46,7 +47,7 @@ EXPORT predict(DATASET(Model) models, DATASET(SVM_Instance) d) := FUNCTION
     SELF.id := m.id;
     SELF.rid := inst.rid;
     SELF.target_y := inst.y;
-    SELF.predict_y := SVM_Predict(m, x_nodes);
+    SELF.predict_y := SVM_Predict(m, x_nodes, SVM_Output.LABEL_ONLY)[1].v;
   END;
   rslt := JOIN(d, svm_mdls, TRUE, predict(LEFT, RIGHT), ALL);
   RETURN rslt;

--- a/ML/SVM/scale_factors.ecl
+++ b/ML/SVM/scale_factors.ecl
@@ -1,0 +1,32 @@
+// Determine scaling factors for instance data
+IMPORT ML.SVM.Types;
+EXPORT DATASET(Types.SVM_Scale)
+       scale_factors(Types.Scale_Parms parms,
+                     DATASET(Types.SVM_Instance) ds) := FUNCTION
+  Types.SVM_Feature extractFeatures(Types.SVM_Feature rec) := TRANSFORM
+    SELF := rec;
+  END;
+  features := NORMALIZE(ds, LEFT.x, extractFeatures(RIGHT));
+  f_stats := TABLE(features, {STRING1 lbl:='1', nominal,
+                              REAL8 mx_v := MAX(GROUP, v),
+                              REAL8 mn_v:= MIN(GROUP, v)},
+                  nominal, FEW, UNSORTED);
+  l_stats := TABLE(ds, {STRING1 lbl:='1', REAL8 mx_v := MAX(GROUP,y),
+                        REAL8 mn_v:=MIN(GROUP, y)},
+                  FEW, UNSORTED);
+  Types.Feature_Scale cvt(RECORDOF(f_stats) f) := TRANSFORM
+    SELF.nominal := f.nominal;
+    SELF.max_value := f.mx_v;
+    SELF.min_value := f.mn_v;
+  END;
+  Types.SVM_Scale mrgData(RECORDOF(l_stats) l, DATASET(RECORDOF(f_stats)) f):=TRANSFORM
+    SELF.y_max := l.mx_v;
+    SELF.y_min := l.mn_v;
+    SELF.features := PROJECT(f, cvt(LEFT));
+    SELF := parms;
+  END;
+  f_grp := SORT(GROUP(f_stats(mx_v<>mn_v), lbl, ALL), nominal);
+  rslt := DENORMALIZE(l_stats, f_grp, LEFT.lbl=RIGHT.lbl, GROUP,
+                      mrgData(LEFT, ROWS(RIGHT)));
+  RETURN rslt;
+END;

--- a/ML/SVM/scale_instance.ecl
+++ b/ML/SVM/scale_instance.ecl
@@ -1,0 +1,28 @@
+IMPORT ML.SVM.Types;
+//
+SVM_Scale := Types.SVM_Scale;
+SVM_Instance := Types.SVM_Instance;
+SVM_Feature := Types.SVM_Feature;
+Feature_Scale := Types.Feature_Scale;
+
+EXPORT scale_instance(DATASET(SVM_Scale) f, DATASET(SVM_Instance) ds) := FUNCTION
+  SVM_Feature scaleF(SVM_Feature f, Feature_Scale fs, REAL8 l, REAL8 u) := TRANSFORM
+    SELF.v := MAP(f.v=fs.min_value    => l,
+                  f.v=fs.max_value    => u,
+                  l+(u-l)*(f.v-fs.min_value)/(fs.max_value-fs.min_value));
+    SELF := f;
+  END;
+  SVM_Instance scaleI(SVM_Instance inst, SVM_Scale sc) := TRANSFORM
+    newF := JOIN(inst.x, sc.features, LEFT.nominal=RIGHT.nominal,
+                 scaleF(LEFT, RIGHT, sc.x_lower, sc.x_upper));
+    newY := sc.y_lower+(sc.y_upper-sc.y_lower)*(inst.y-sc.y_min)/(sc.y_max-sc.y_min);
+    SELF.max_value := MAX(newF, v);
+    SELF.x := newF;
+    SELF.y := MAP(inst.y=sc.y_min  => sc.y_lower,
+                  inst.y=sc.y_max  => sc.y_upper,
+                  newY);
+    SELF := inst;
+  END;
+  rslt := JOIN(ds, f, TRUE, scaleI(LEFT,RIGHT), ALL);
+  RETURN rslt;
+END;

--- a/ML/SVM/train.ecl
+++ b/ML/SVM/train.ecl
@@ -1,0 +1,59 @@
+IMPORT ML.SVM.Types;
+IMPORT ML.SVM.LibSVM.Types AS LibSVM_Types;
+IMPORT ML.SVM.LibSVM;
+IMPORT ML.SVM.LibSVM.Converted;
+// aliases for convenience
+Parms := Types.Training_Parameters;
+Instance := Types.SVM_Instance;
+Model := Types.Model;
+Problem := LibSVM_Types.ECL_LibSVM_Problem;
+LibSVM_Parms := LibSVM_Types.ECL_LibSVM_Train_Param;
+LibSVM_Model := LibSVM_Types.ECL_LibSVM_Model;
+SVM_SV := Types.SVM_SV;
+SVM_Feature := Types.SVM_Feature;
+
+
+EXPORT DATASET(Model) train(DATASET(Parms) p, DATASET(Instance) d):= FUNCTION
+  Work1 := RECORD(LibSVM_Parms)
+    Types.Model_ID id;
+  END;
+  Work1 cvt2Parm(Parms p) := TRANSFORM
+    SELF.cache_size := 100;
+    SELF.shrinking := IF(p.shrinking, 1, 0);
+    SELF.prob_est := IF(p.prob_est, 1, 0);
+    SELF := p;
+  END;
+  parm_data := PROJECT(p, cvt2Parm(LEFT));
+  problem_data := Converted.Instance2Problem(d); // 1 record file
+
+  Work_F := RECORD(SVM_Feature)
+    UNSIGNED4 v_ord;
+    BOOLEAN keep_me;
+  END;
+  Work_F cvtNode(LibSVM_Types.LibSVM_Node node) := TRANSFORM
+    SELF.v_ord := IF(node.indx >=0, 0, 1);
+    SELF.nominal := node.indx;
+    SELF.v := node.value;
+    SELF.keep_me := node.indx >= 0;   // not end mark
+  END;
+  Work_F vidMark(Work_F prev, Work_F curr) := TRANSFORM
+    SELF.v_ord := IF(prev.v_ord=0,1, prev.v_ord+curr.v_ord);
+    SELF := curr;
+  END;
+  SVM_SV rollF(Work_F f_1, DATASET(Work_F) f_set) := TRANSFORM
+    SELF.v_ord := f_1.v_ord;
+    SELF.features := PROJECT(f_set, SVM_Feature);
+  END;
+  Model LibSVM_Call(Work1 prm, Problem d) := TRANSFORM
+    LibSVM_Model mdl := LibSVM.svm_train(prm, d);
+    raw_features := PROJECT(mdl.sv, cvtNode(LEFT));
+    marked_features := ITERATE(raw_features, vidMark(LEFT,RIGHT))(keep_me);
+    grouped_features := GROUP(marked_features, v_ord);
+    SELF.id := prm.id;
+    SELF.sv := ROLLUP(grouped_features, GROUP, rollF(LEFT,ROWS(LEFT)));
+    SELF := mdl;
+  END;
+  rslt := JOIN(parm_data, problem_data, TRUE,
+               LibSVM_Call(LEFT, RIGHT), ALL);
+  RETURN rslt;
+END;


### PR DESCRIPTION
Added support to use LibSVM.  The ECL is used to run multiple models across all nodes in the cluster to parallelize the training, and then run a model on multiple nodes to parallelize the predictions.  The training data must still fit on a single node.