### PR TITLE
[ML-307] Fix Multiclass libSVM C++ Attributes

### DIFF
--- a/ML/SVM/LibSVM/svm_predict.ecl
+++ b/ML/SVM/LibSVM/svm_predict.ecl
@@ -1,4 +1,4 @@
-// Predict Y for a vector
+﻿// Predict Y for a vector
 // Create a model from training data
 IMPORT ML.SVM.LibSVM.Types;
 IMPORT ML.SVM.LibSVM.Constants;
@@ -85,7 +85,7 @@ EXPORT DATASET(R8Entry) svm_predict(Model ecl_model, DATASET(Node) ecl_nodes,
   for (uint32_t i=0; i<in_mdl->k-1; i++) {
     mdl->sv_coef[i] = (double*) malloc(in_mdl->l*sizeof(double));
     for (uint32_t j=0; j<in_mdl->l; j++) {
-      mdl->sv_coef[i][j] = sv_coef[((in_mdl->k-1)*i)+j];
+      mdl->sv_coef[i][j] = sv_coef[((in_mdl->l)*i)+j];
     }
   }
   // rho

--- a/ML/SVM/LibSVM/svm_train.ecl
+++ b/ML/SVM/LibSVM/svm_train.ecl
@@ -1,4 +1,4 @@
-// Create a model from training data
+﻿// Create a model from training data
 IMPORT ML.SVM.LibSVM.Types;
 IMPORT ML.SVM.LibSVM.Constants;
 IMPORT ML.SVM.LibSVM.Converted;
@@ -182,7 +182,7 @@ DATA svm_train_d(SVM_Parms prm,
   double* sv_coef = (double*) (sv_array + elements);
   for (int i=0; i<model->nr_class-1; i++) {
     for (int j=0; j<model->l; j++) {
-      sv_coef[((model->nr_class-1)*i)+j] = model->sv_coef[i][j];
+      sv_coef[((model->l)*i)+j] = model->sv_coef[i][j];
     }
    }
   //


### PR DESCRIPTION
In ML/SVM/LibSVM/svm_train.ecl and ML/SVM/lbSVM/svm_train.ecl , the components sv_coef uses wrong formula for 2d addressing for moving them in and out of libSVM interface.
Change from (i * no_of_cols + j) to (i * no_of_rows + j).
This fixes the issue.