### PR TITLE
[ML-308] Fix references to t_level in Lazy/KNN

### DIFF
--- a/ML/Lazy.ecl
+++ b/ML/Lazy.ecl
@@ -1,5 +1,6 @@
 ﻿IMPORT ML;
 IMPORT * FROM $;
+
 /*
 Instance-based learning
 From Wikipedia, the free encyclopedia http://en.wikipedia.org/wiki/Instance-based_learning
@@ -25,7 +26,7 @@ EXPORT Lazy:= MODULE
   END; // End of General KNN Classifier
   
   // Particular KNN Classifier => using KDTree Nearest Neighbors Search
-  EXPORT KNN_KDTree(CONST Types.t_count NN_count=5, Trees.t_level Depth=10,Trees.t_level MedianDepth=15):= MODULE(KNN(NN_count))
+  EXPORT KNN_KDTree(CONST Types.t_count NN_count=5, Types.t_level Depth=10, Types.t_level MedianDepth=15):= MODULE(KNN(NN_count))
     KNNSearch:= ML.NearestNeighborsSearch.KDTreeNNSearch(NN_count, Depth, MedianDepth);
     EXPORT ClassifyC(DATASET(Types.NumericField) indepData , DATASET(Types.DiscreteField) depData ,DATASET(Types.NumericField) queryPointsData):= FUNCTION
       Neighbors:= KNNSearch.SearchC(indepData , queryPointsData);

--- a/ML/NearestNeighborsSearch.ecl
+++ b/ML/NearestNeighborsSearch.ecl
@@ -1,5 +1,7 @@
-IMPORT ML;
+﻿IMPORT ML;
+IMPORT ML.Trees;
 IMPORT * FROM $;
+
 EXPORT NearestNeighborsSearch:= MODULE
     EXPORT leafData := RECORD
       Types.t_RecordID qp_id;
@@ -21,11 +23,11 @@ EXPORT NearestNeighborsSearch:= MODULE
     CoverTree
   Thus we create NearestNeighborsSearch as Virtual, all of them need to implement the algorithm in SearchC and return K-Nearest Neighbors
 */
-  EXPORT KDTreeNNSearch(CONST Types.t_count NN_count=5, Trees.t_level Depth=10,Trees.t_level MedianDepth=0) := MODULE(DEFAULT)
+  EXPORT KDTreeNNSearch(CONST Types.t_count NN_count=5, Types.t_level Depth=10, Types.t_level MedianDepth=0) := MODULE(DEFAULT)
     SHARED query_point := RECORD
       Types.t_RecordID id;                    // id of query point
       Types.t_FieldNumber p_number:=    0;    // qp attribute
-      Types.t_FieldReal p_value:=       0;    // qp atribute�s value
+      Types.t_FieldReal p_value:=       0;    // qp atribute’s value
       Types.t_RecordID node_id;               // id of the current node in the search
       Types.t_FieldNumber split_number:=0;    // attribute used to split
       Types.t_FieldReal split_value:=  -1;    // split value


### PR DESCRIPTION
Change Trees.t_level to ML.Types.t_level in ML/Lazy.ecl and ML/NearestNeighborSearch.ecl .