### PR TITLE
ML-309 KMeans clustering using Dense model ignores convergence threshold

### DIFF
--- a/ML/Cluster.ecl
+++ b/ML/Cluster.ecl
@@ -244,7 +244,8 @@ EXPORT Cluster := MODULE
     // method specified by the user for this module
     SHARED dDistanceDelta(UNSIGNED n01=n-1,UNSIGNED n02=n,DATASET(lIterations) d):=FUNCTION
       iMax01:=MAX(dResult(n01,d),id);
-      dDistances:=Distances(dResult(n01,d),PROJECT(dResult(n02,d),TRANSFORM(Types.NumericField,SELF.id:=LEFT.id+iMax01;SELF:=LEFT;)),fDist);
+      convergence:=COUNT(d[1].values)-1;
+      dDistances:=Distances(dResult(IF(convergence<n01,n02,n01),d),PROJECT(dResult(n02,d),TRANSFORM(Types.NumericField,SELF.id:=LEFT.id+iMax01;SELF:=LEFT;)),fDist);
       RETURN PROJECT(dDistances(x=y-iMax01),TRANSFORM({Types.NumericField AND NOT [number];},SELF.id:=LEFT.x;SELF:=LEFT;));
     END;
 


### PR DESCRIPTION
KMeans clustering function takes 5 parameters: the document dataset, the centroid
dataset, the number of iterations to perform, the convergence threshold, and the
distance measure to use. The KMeans clustering performs the requested number of
iterations unless the maximum distance moved by a centroid in any iteration
goes below the convergence threshold. The KMeans should stop iterating in that case.

Fix KMeans clustering using Dense model to ensure that KMeans function stops
iterating when the convergence threshold condition is satisfied.

Fixed ML-309

Signed-off-by: emuharemagic edin.muharemagic@lexisnexis.com