### PR TITLE
ML-270: Modifications to optimize Yingyang k-means

### DIFF
--- a/ML/Tests/Explanatory/Cluster.ecl
+++ b/ML/Tests/Explanatory/Cluster.ecl
@@ -10,132 +10,53 @@
 //---------------------------------------------------------------------------
 
 IMPORT ML;
+IMPORT ML.Types as Types;
+IMPORT ML.Mat as Mat;
+IMPORT excercise.uscensus as uscensus;
 
-lMatrix:={UNSIGNED id;REAL x;REAL y;};
+//USCENSUS data
+dDocumentMatrix := uscensus.input;
 
-dDocumentMatrix:=DATASET([
-{1,2.4639,7.8579},
-{2,0.5573,9.4681},
-{3,4.6054,8.4723},
-{4,1.24,7.3835},
-{5,7.8253,4.8205},
-{6,3.0965,3.4085},
-{7,8.8631,1.4446},
-{8,5.8085,9.1887},
-{9,1.3813,0.515},
-{10,2.7123,9.2429},
-{11,6.786,4.9368},
-{12,9.0227,5.8075},
-{13,8.55,0.074},
-{14,1.7074,3.9685},
-{15,5.7943,3.4692},
-{16,8.3931,8.5849},
-{17,4.7333,5.3947},
-{18,1.069,3.2497},
-{19,9.3669,7.7855},
-{20,2.3341,8.5196},
-{21,0.5004,2.2394},
-{22,6.5147,1.8744},
-{23,5.1284,2.0043},
-{24,3.555,1.3365},
-{25,1.9224,8.0774},
-{26,6.6664,9.9721},
-{27,2.5007,5.2815},
-{28,8.7526,6.6125},
-{29,0.0898,3.9292},
-{30,1.2544,9.5753},
-{31,1.5462,8.4605},
-{32,3.723,4.1098},
-{33,9.8581,8.0831},
-{34,4.0208,2.7462},
-{35,4.6232,1.3271},
-{36,1.5694,2.168},
-{37,1.8174,4.779},
-{38,9.2858,3.3175},
-{39,7.1321,2.2322},
-{40,2.9921,3.2818},
-{41,7.0561,9.2796},
-{42,1.4107,2.6271},
-{43,5.1149,8.3582},
-{44,6.8967,7.6558},
-{45,0.0982,8.2855},
-{46,1.065,4.9598},
-{47,0.3701,3.7443},
-{48,3.1341,8.8177},
-{49,3.1314,7.3348},
-{50,9.6476,3.3575},
-{51,6.1636,5.3563},
-{52,8.9044,7.8936},
-{53,9.7695,9.6457},
-{54,2.3383,2.229},
-{55,5.9883,9.3733},
-{56,9.3741,4.4313},
-{57,8.4276,2.9337},
-{58,8.2181,1.0951},
-{59,3.2603,6.9417},
-{60,3.0235,0.8046},
-{61,1.0006,9.4768},
-{62,8.5635,9.2097},
-{63,5.903,7.6075},
-{64,4.3534,7.5549},
-{65,8.2062,3.453},
-{66,9.0327,8.9012},
-{67,8.077,8.6283},
-{68,4.7475,5.5387},
-{69,2.4441,7.106},
-{70,8.1469,1.1593},
-{71,5.0788,5.315},
-{72,5.1421,9.8605},
-{73,7.7034,2.019},
-{74,3.5393,2.2992},
-{75,2.804,1.3503},
-{76,4.7581,2.2302},
-{77,2.6552,1.7776},
-{78,7.4403,5.5851},
-{79,2.6909,9.7426},
-{80,7.2932,5.4318},
-{81,5.7443,4.3915},
-{82,3.3988,9.8385},
-{83,2.5105,3.6425},
-{84,4.3386,4.9175},
-{85,6.5916,5.7468},
-{86,2.7913,7.4308},
-{87,9.3152,5.4451},
-{88,9.3501,3.9941},
-{89,1.7224,4.6733},
-{90,6.6617,1.6269},
-{91,3.0622,1.9185},
-{92,0.6733,2.4744},
-{93,1.355,1.0267},
-{94,3.75,9.499},
-{95,7.2441,0.5949},
-{96,3.3434,4.9163},
-{97,8.7538,5.3958},
-{98,7.4316,2.6315},
-{99,3.6239,5.3696},
-{100,3.2393,3.0533}
-],lMatrix);
+//The length of USCENSUSD data
+dDoc_len := COUNT(dDocumentMatrix);
 
-dCentroidMatrix:=DATASET([
-{1,1,1},
-{2,2,2},
-{3,3,3},
-{4,4,4}
-],lMatrix);
+//Define the number of clusters K and the number of groups G for YinyangKmeans Algorithm
+k := 100;
+g := k/10;
+
+//The maximum number of iterations
+ite :=100;
+
+//Generate reamdom number within a specified range
+INTEGER ranger(INTEGER lower, INTEGER upper) := FUNCTION
+RETURN lower + random()% (upper - lower);
+END;
+
+d := record
+INTEGER id;
+END;
+
+//Initial Centroids
+kSet := DATASET(k, TRANSFORM(d, SELF.id := ranger(1, dDoc_len)));
+OUTPUT(kset, , '~lili::kset' + RANDOM());
+dCentroidMatrix := dDocumentMatrix(dDocumentMatrix.id IN SET(kSet,id));
+
+//Initial Groups
+gSet := DATASET(g, TRANSFORM(d, SELF.id := RANDOM()%k));
+dGt := PROJECT(gSet, transform(RECORDOF(dCentroidMatrix), self := dCentroidMatrix[left.id]));
+
 
 ML.ToField(dDocumentMatrix,dDocuments);
 ML.ToField(dCentroidMatrix,dCentroids);
+ML.ToField(dGt, dt)
 
-                                                         // EXAMPLES
-KMeans:=ML.Cluster.KMeans(dDocuments,dCentroids,30,.3);  // Set up KMeans with a maximum of 30 iterations and .3 as a convergence threshold
-KMeans.Allresults;                                       // The table that contains the results of each iteration
-KMeans.Convergence;                                      // The number of iterations it took to converge
-KMeans.Result(12);                                       // The results of iteration 12
-KMeans.Delta(5,15);                                      // The distance every centroid travelled across each axis from iterations 5 to 15
-KMeans.Delta(0);                                         // The total distance the centroids travelled on each axis
-KMeans.DistanceDelta(5,15);                              // The straight-line distance travelled by each centroid from iterations 5 to 15
-KMeans.DistanceDelta(0);                                 // The total straight-line distance each centroid travelled 
-KMeans.DistanceDelta();                                  // The distance travelled by each centroid during the last iteration.
+                                                                              // EXAMPLES
+KMeans:=ML.Cluster.KMeans(dDocuments,dCentroids,ite,.3);                      // Set up KMeans with a maximum of 30 iterations and .3 as a convergence threshold
+KMeans.Allresults;                                                            // The table that contains the results of each iteration
+KMeans.Convergence;                                                           // The number of iterations it took to converge
 
 
+YinyangKMeans:=ML.Cluster.YinyangKMeans(dDocuments,dCentroids,dt,ite,0.3); 		// Set up YinYangKMeans with a maximum of 30 iterations and .3 as a convergence threshold
+YinyangKMeans.Allresults;                                       					    // The table that contains the results of each iteration
+YinyangKMeans.Convergence;                                      					    // The number of iterations it took to converge
 


### PR DESCRIPTION
Project : Implementing and Optimizing Yinyang K-Means Clustering Algorithm in HPCC Systems
Contributor : Lily Xu

This project is implementing Yinyang K-Means Clustering Algorithm in ECL and added to the HPCC-Systems Machine Learning Library. The Yingyang algorithm is an exact and thus 'drop-in' replacement for the standard k-means clustering measure.

The abstract from the principle paper by Ding, Zhao, Shen, et al. follows:
"This paper presents Yinyang K-means, a new algorithm for K-means clustering. By clustering the centers in the initial stage, and leveraging efficiently maintained lower and upper bounds between a point and centers, it more effectively avoids unnecessary distance calculations than prior algorithms. It significantly outperforms prior K-means algorithms consistently across all experimented data sets, cluster numbers, and machine configurations. The consistent, superior performance—plus its simplicity, user-control of overheads, and guarantee in producing the same clustering results as the standard K-means does—makes Yinyang K-means a drop-in replacement of the classic K-means with an order of magnitude higher performance."[1]

For the detail of Yinyang K-Mean algorithm, please refer to the paper.
[ 1 ] Ding, Y., Zhao, Y., Shen, X., Musuvathi, M., & Mytkowicz, T. (2015). Yinyang k-means: A drop-in replacement of the classic k-means with consistent speedup. In Proceedings of the 32nd International Conference on Machine Learning (ICML-15) (pp. 579-587).

JIRA Ticket : ML-270
Link: https://track.hpccsystems.com/browse/ML-270?jql=text%20~%20%22yinyang%22