### PR TITLE
Added labels to Pred_Prob_Est results

### DIFF
--- a/ML/SVM/Types.ecl
+++ b/ML/SVM/Types.ecl
@@ -109,5 +109,6 @@ EXPORT Types := MODULE
   END;
   EXPORT SVM_Pred_Prob_Est := RECORD(SVM_Prediction)
     DATASET(R8Entry) prob_estimates;
+	DATASET(I4Entry) labels;
   END;
 END;

--- a/ML/SVM/predict.ecl
+++ b/ML/SVM/predict.ecl
@@ -1,4 +1,4 @@
-// Produce a data set of predictions for each model
+﻿// Produce a data set of predictions for each model
 IMPORT ML.SVM;
 IMPORT ML.SVM.LibSVM;
 // aliases
@@ -75,6 +75,7 @@ EXPORT Predict(DATASET(Model) models, DATASET(SVM_Instance) d) := MODULE
     SELF.target_y := inst.y;
     SELF.predict_y := rslt_array[1].v;
     SELF.prob_estimates := CHOOSEN(rslt_array, ALL, 2);
+    SELF.labels := m.labels;
   END;
   EXPORT Pred_Prob_Est := JOIN(d, svm_mdls, TRUE, p_pest(LEFT, RIGHT), ALL);
 END;


### PR DESCRIPTION
Adding labels to Pred_Prob_Est results will help to identify the label
returned for each probability value.
e.g. first value of the labels array corresponds to first value of the
prob_estimates array.