### PR TITLE
ML-405 Remove typedefs to fix compiler warning

### DIFF
--- a/ML/SVM/LibSVM/svm_cross_validate.ecl
+++ b/ML/SVM/LibSVM/svm_cross_validate.ecl
@@ -19,7 +19,7 @@ EXPORT Result svm_cross_validate(SVM_Parms prm,
     #endif
     #ifndef ECL_LIBSVM_TRAIN_PARAM
     #define ECL_LIBSVM_TRAIN_PARAM
-      typedef struct __attribute__ ((__packed__)) ecl_svm_parameter {
+      struct __attribute__ ((__packed__)) ecl_svm_parameter {
         unsigned short svm_type;
         unsigned short kernel_type;
         int degree;
@@ -37,7 +37,7 @@ EXPORT Result svm_cross_validate(SVM_Parms prm,
     #endif
     #ifndef ECL_SVM_PROBLEM
     #define ECL_SVM_PROBLEM
-      typedef struct __attribute__ ((__packed__)) ecl_svm_problem {
+      struct __attribute__ ((__packed__)) ecl_svm_problem {
         unsigned int elements;
         int entries;
         unsigned int features;
@@ -46,14 +46,14 @@ EXPORT Result svm_cross_validate(SVM_Parms prm,
     #endif
     #ifndef ECL_SVM_NODE
     #define ECL_SVM_NODE
-      typedef struct __attribute__ ((__packed__))  Packed_SVM_Node {
+      struct __attribute__ ((__packed__))  Packed_SVM_Node {
         int indx;
         double value;
       };
     #endif
     #ifndef ECL_CROSSVALIDATE_RESULT
     #define ECL_CROSSVALIDATE_RESULT
-      typedef struct CrossValidate_Result {
+      struct CrossValidate_Result {
         double mse;
         double r_sq;
         double correct;

--- a/ML/SVM/LibSVM/svm_predict.ecl
+++ b/ML/SVM/LibSVM/svm_predict.ecl
@@ -19,14 +19,14 @@ EXPORT DATASET(R8Entry) svm_predict(Model ecl_model, DATASET(Node) ecl_nodes,
   #endif
     #ifndef ECL_SVM_NODE
     #define ECL_SVM_NODE
-    typedef struct __attribute__ ((__packed__))  Packed_SVM_Node {
+    struct __attribute__ ((__packed__))  Packed_SVM_Node {
       int indx;
       double value;
     };
   #endif
   #ifndef ECL_SVM_MODEL
   #define ECL_SVM_MODEL
-    typedef struct __attribute__ ((__packed__)) Packed_SVM_Model {
+    struct __attribute__ ((__packed__)) Packed_SVM_Model {
       unsigned short svm_type;
       unsigned short kernel_type;
       int degree;

--- a/ML/SVM/LibSVM/svm_train.ecl
+++ b/ML/SVM/LibSVM/svm_train.ecl
@@ -18,7 +18,7 @@ DATA svm_train_d(SVM_Parms prm,
   #endif
   #ifndef ECL_LIBSVM_TRAIN_PARAM
   #define ECL_LIBSVM_TRAIN_PARAM
-    typedef struct __attribute__ ((__packed__)) ecl_svm_parameter {
+    struct __attribute__ ((__packed__)) ecl_svm_parameter {
       unsigned short svm_type;
       unsigned short kernel_type;
       int degree;
@@ -36,7 +36,7 @@ DATA svm_train_d(SVM_Parms prm,
   #endif
   #ifndef ECL_SVM_PROBLEM
   #define ECL_SVM_PROBLEM
-    typedef struct __attribute__ ((__packed__)) ecl_svm_problem {
+    struct __attribute__ ((__packed__)) ecl_svm_problem {
       unsigned int elements;
       int entries;
       unsigned int features;
@@ -45,14 +45,14 @@ DATA svm_train_d(SVM_Parms prm,
     #endif
     #ifndef ECL_SVM_NODE
     #define ECL_SVM_NODE
-    typedef struct __attribute__ ((__packed__))  Packed_SVM_Node {
+    struct __attribute__ ((__packed__))  Packed_SVM_Node {
       int indx;
       double value;
     };
   #endif
   #ifndef ECL_SVM_MODEL
   #define ECL_SVM_MODEL
-    typedef struct __attribute__ ((__packed__)) Packed_SVM_Model {
+    struct __attribute__ ((__packed__)) Packed_SVM_Model {
       unsigned short svm_type;
       unsigned short kernel_type;
       int degree;


### PR DESCRIPTION
Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>